### PR TITLE
feat: Homebrew tap formula with brew-aware commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,21 @@ changelog:
     - title: Other work
       order: 9999
 
+homebrew_casks:
+  - repository:
+      owner: GreyhavenHQ
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/GreyhavenHQ/greywall"
+    description: "Sandboxed command execution with network isolation"
+    license: "Apache-2.0"
+    binaries:
+      - greywall
+    dependencies:
+      - cask: greyproxy
+    caveats: |
+      Run 'greywall setup' to start the greyproxy service.
+
 release:
   draft: false
   prerelease: auto

--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -459,11 +459,24 @@ func runCheck(_ *cobra.Command, _ []string) error {
 	steps := sandbox.PrintDependencyStatus()
 
 	status := proxy.Detect()
+	brewManaged := proxy.IsBrewManaged(status.Path)
+
+	installHint := "greywall setup"
+	upgradeHint := "greywall setup"
+	if brewManaged {
+		upgradeHint = "brew upgrade greyproxy"
+	} else if selfPath, err := os.Executable(); err == nil && proxy.IsBrewManaged(selfPath) {
+		installHint = "brew install greyproxy"
+	}
+
 	if status.Installed {
 		if status.Version != "" {
 			fmt.Println(sandbox.CheckOK(fmt.Sprintf("greyproxy (v%s)", status.Version)))
 		} else {
 			fmt.Println(sandbox.CheckOK("greyproxy"))
+		}
+		if brewManaged {
+			fmt.Println(sandbox.CheckOK("greyproxy installed via Homebrew"))
 		}
 		if status.Running {
 			fmt.Println(sandbox.CheckOK("greyproxy running (SOCKS5 :43052, DNS :43053)"))
@@ -475,13 +488,13 @@ func runCheck(_ *cobra.Command, _ []string) error {
 		if latest, err := proxy.CheckLatestVersion(); err == nil {
 			if proxy.IsOlderVersion(status.Version, latest) {
 				fmt.Println(sandbox.CheckFail(fmt.Sprintf("greyproxy up-to-date (v%s available, installed v%s)", latest, status.Version)))
-				steps = append(steps, "greywall setup")
+				steps = append(steps, upgradeHint)
 			}
 		}
 	} else {
 		fmt.Println(sandbox.CheckFail("greyproxy"))
 		fmt.Println(sandbox.CheckFail("greyproxy running"))
-		steps = append(steps, "greywall setup")
+		steps = append(steps, installHint)
 	}
 
 	if len(steps) > 0 {
@@ -533,7 +546,12 @@ func runSetup(_ *cobra.Command, _ []string) error {
 			return nil
 		}
 		if proxy.IsOlderVersion(status.Version, latest) {
-			fmt.Printf("greyproxy update available: v%s → v%s\n", status.Version, latest)
+			fmt.Printf("greyproxy update available: v%s -> v%s\n", status.Version, latest)
+			if proxy.IsBrewManaged(status.Path) {
+				fmt.Printf("greyproxy is managed by Homebrew. To update, run:\n")
+				fmt.Printf("  brew upgrade greyproxy\n")
+				return nil
+			}
 			fmt.Printf("Upgrading...\n")
 			return proxy.Install(proxy.InstallOptions{
 				Output: os.Stderr,
@@ -549,6 +567,13 @@ func runSetup(_ *cobra.Command, _ []string) error {
 			return err
 		}
 		fmt.Printf("greyproxy started.\n")
+		return nil
+	}
+
+	// Check if greywall itself was installed via brew; if so, suggest brew for greyproxy too.
+	if selfPath, err := os.Executable(); err == nil && proxy.IsBrewManaged(selfPath) {
+		fmt.Printf("greyproxy is not installed. Since greywall was installed via Homebrew, run:\n")
+		fmt.Printf("  brew install greyproxy\n")
 		return nil
 	}
 

--- a/internal/proxy/brew.go
+++ b/internal/proxy/brew.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// IsBrewManaged returns true if the greyproxy binary at the given path
+// is managed by Homebrew (i.e. lives under a Homebrew prefix).
+func IsBrewManaged(binaryPath string) bool {
+	if binaryPath == "" {
+		return false
+	}
+
+	brewPrefix := brewPrefixPath()
+	if brewPrefix == "" {
+		return false
+	}
+
+	return strings.HasPrefix(binaryPath, brewPrefix)
+}
+
+// brewPrefixPath returns the Homebrew prefix (e.g. /opt/homebrew, /usr/local).
+func brewPrefixPath() string {
+	out, err := exec.Command("brew", "--prefix").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}


### PR DESCRIPTION
## Summary
- Adds `brews` section to `.goreleaser.yaml` with `depends_on "greyproxy"` (required)
- New `internal/proxy/brew.go` detects if greyproxy lives under a Homebrew prefix
- `greywall check` shows brew status and suggests `brew upgrade greyproxy` when outdated
- `greywall setup` detects brew-managed installs and suggests brew commands instead of overwriting

## Context
This is step 2 of the Homebrew distribution setup. **Must be released after greyproxy** so the `greyproxy` formula already exists in the tap.

Depends on: https://github.com/GreyhavenHQ/greyproxy/pull/8

## Test plan
- [ ] Merge and release greyproxy PR first
- [ ] Verify `brew install greyhavenhq/tap/greyproxy` works
- [ ] Merge this PR and tag a greywall release
- [ ] Verify `brew install greyhavenhq/tap/greywall` pulls in greyproxy
- [ ] `greywall check` shows "greyproxy installed via Homebrew"
- [ ] `greywall setup` with outdated brew greyproxy suggests `brew upgrade`