### PR TITLE
fix: add user-configured allowRead paths to Landlock ruleset

### DIFF
--- a/internal/sandbox/linux_landlock.go
+++ b/internal/sandbox/linux_landlock.go
@@ -152,6 +152,25 @@ func ApplyLandlockFromConfig(cfg *config.Config, cwd string, socketPaths []strin
 		}
 	}
 
+	// User-configured allowRead paths
+	if cfg != nil && cfg.Filesystem.AllowRead != nil {
+		expandedPaths := ExpandGlobPatterns(cfg.Filesystem.AllowRead)
+		for _, p := range expandedPaths {
+			if err := ruleset.AllowRead(p); err != nil && debug {
+				fmt.Fprintf(os.Stderr, "[greywall:landlock] Warning: failed to add read path %s: %v\n", p, err)
+			}
+		}
+		// Also add non-glob paths directly
+		for _, p := range cfg.Filesystem.AllowRead {
+			if !ContainsGlobChars(p) {
+				normalized := NormalizePath(p)
+				if err := ruleset.AllowRead(normalized); err != nil && debug {
+					fmt.Fprintf(os.Stderr, "[greywall:landlock] Warning: failed to add read path %s: %v\n", normalized, err)
+				}
+			}
+		}
+	}
+
 	// User-configured allowWrite paths
 	if cfg != nil && cfg.Filesystem.AllowWrite != nil {
 		expandedPaths := ExpandGlobPatterns(cfg.Filesystem.AllowWrite)


### PR DESCRIPTION
## Summary

- `ApplyLandlockFromConfig` was not processing `cfg.Filesystem.AllowRead` paths, only hardcoded system/tooling paths and `AllowWrite` paths
- Since Landlock is deny-by-default, any user-configured `allowRead` path (e.g. `~/.gitconfig`) was blocked despite bwrap mounting it correctly as `--ro-bind`
- Added `AllowRead` processing mirroring the existing `AllowWrite` pattern, with glob expansion and direct path support

Closes #6

## Test plan

- [x] Run `greywall --debug` with `allowRead: ["~/.gitconfig"]` and `denyWrite: ["~/.gitconfig"]` in config; verify `~/.gitconfig` appears in Landlock rules output
- [x] Run `git log` inside sandbox; verify no `Permission denied` on `.gitconfig`
- [x] Run `make test` to verify no regressions
