### PR TITLE
fix: always allow localhost bind/inbound in macOS Seatbelt profile

### DIFF
--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -578,16 +578,17 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 	if !params.NeedsNetworkRestriction {
 		profile.WriteString("(allow network*)\n")
 	} else {
-		if params.AllowLocalBinding {
-			// Allow binding and inbound connections on localhost (for servers)
-			profile.WriteString(`(allow network-bind (local ip "localhost:*"))
+		// Always allow localhost binding and inbound connections.
+		// This matches Linux behavior where the isolated network namespace
+		// allows unrestricted local binding. Many tools need this for OAuth
+		// callbacks, MCP servers, dev servers, etc.
+		profile.WriteString(`(allow network-bind (local ip "localhost:*"))
 (allow network-inbound (local ip "localhost:*"))
 `)
-			// Process can make outbound connections to localhost
-			if params.AllowLocalOutbound {
-				profile.WriteString(`(allow network-outbound (local ip "localhost:*"))
+		// Process can make outbound connections to localhost
+		if params.AllowLocalOutbound {
+			profile.WriteString(`(allow network-outbound (local ip "localhost:*"))
 `)
-			}
 		}
 
 		if params.AllowAllUnixSockets {


### PR DESCRIPTION
## Summary

- On macOS, the Seatbelt sandbox's `(deny default)` blocked `network-bind` and `network-inbound`, preventing tools from starting local servers (e.g. Claude's `/login` OAuth callback on port 0)
- On Linux, the isolated network namespace allows unrestricted local binding; this aligns macOS behavior to match
- Outbound connections to localhost remain gated on `AllowLocalOutbound`, preserving the security boundary

## Test plan

- [ ] Run `greywall -- claude` on macOS and verify `/login` OAuth flow completes
- [ ] Verify sandboxed processes can bind to localhost ports without needing `allowLocalBinding` in config
- [ ] Verify sandboxed processes still cannot make outbound connections to localhost services (unless `allowLocalOutbound` is set)
- [ ] Run `make test` on both platforms