### PR TITLE
feat: inject keyring credentials for gh/glab profiles via secret-tool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
             bubblewrap \
             socat \
             xdg-dbus-proxy \
+            libsecret-tools \
             uidmap \
             curl \
             netcat-openbsd \

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ make setup && make build
 - `bubblewrap` - container-free sandboxing (required)
 - `socat` - network bridging (required)
 - `xdg-dbus-proxy` - filtered D-Bus proxy for notify-send support (optional)
+- `libsecret-tools` - keyring credential injection for gh/glab (optional)
 
 Check dependency status with `greywall check`.
 

--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -363,6 +363,30 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Inject keyring secrets for active profiles (Linux only).
+	// This reads from the host keyring before sandboxing blocks D-Bus access.
+	// Check the command itself and any explicitly loaded profiles.
+	if !learning {
+		profileNames := []string{cmdName}
+		if profileName != "" {
+			for _, name := range strings.Split(profileName, ",") {
+				name = strings.TrimSpace(name)
+				if name != "" {
+					profileNames = append(profileNames, name)
+				}
+			}
+		}
+		for _, name := range profileNames {
+			canonical := profiles.IsKnownAgent(name)
+			if canonical == "" {
+				continue
+			}
+			if secrets := profiles.GetKeyringSecrets(canonical); secrets != nil {
+				hardenedEnv = append(hardenedEnv, profiles.ResolveKeyringSecrets(secrets, debug)...)
+			}
+		}
+	}
+
 	execCmd := exec.Command("sh", "-c", sandboxedCommand) //nolint:gosec // sandboxedCommand is constructed from user input - intentional
 	execCmd.Env = hardenedEnv
 	execCmd.Stdin = os.Stdin

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,16 +23,16 @@ On Linux, you also need:
 
 ```bash
 # Ubuntu/Debian
-sudo apt install bubblewrap socat xdg-dbus-proxy
+sudo apt install bubblewrap socat xdg-dbus-proxy libsecret-tools
 
 # Fedora
-sudo dnf install bubblewrap socat xdg-dbus-proxy
+sudo dnf install bubblewrap socat xdg-dbus-proxy libsecret
 
 # Arch
-sudo pacman -S bubblewrap socat xdg-dbus-proxy
+sudo pacman -S bubblewrap socat xdg-dbus-proxy libsecret
 ```
 
-`xdg-dbus-proxy` is optional but recommended. It enables `notify-send` inside the sandbox while keeping the D-Bus session bus isolated.
+`xdg-dbus-proxy` is optional but recommended (enables `notify-send` inside the sandbox). `libsecret-tools` provides `secret-tool` for injecting keyring credentials (e.g., gh OAuth token) into the sandbox.
 
 ### Do I need sudo to run greywall?
 

--- a/internal/profiles/keyring.go
+++ b/internal/profiles/keyring.go
@@ -1,0 +1,65 @@
+package profiles
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ResolveKeyringSecrets reads secrets from the host keyring and returns them
+// as environment variable entries (KEY=VALUE). Only runs on Linux where
+// secret-tool is available. Secrets are read before sandboxing so the
+// D-Bus session bus (required by secret-tool) is still accessible.
+//
+// If an env var is already set in the environment, the keyring lookup is
+// skipped for that variable (explicit env takes precedence).
+func ResolveKeyringSecrets(secrets map[string]KeyringLookup, debug bool) []string {
+	if len(secrets) == 0 || runtime.GOOS != "linux" {
+		return nil
+	}
+
+	secretToolPath, err := exec.LookPath("secret-tool")
+	if err != nil {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[greywall:keyring] secret-tool not found, skipping keyring injection\n")
+		}
+		return nil
+	}
+
+	var envVars []string
+	for envName, lookup := range secrets {
+		// Skip if already set in the environment
+		if os.Getenv(envName) != "" {
+			if debug {
+				fmt.Fprintf(os.Stderr, "[greywall:keyring] %s already set, skipping keyring lookup\n", envName)
+			}
+			continue
+		}
+
+		cmd := exec.Command(secretToolPath, "lookup", "service", lookup.Service) //nolint:gosec // args from trusted profile definitions
+		out, err := cmd.Output()
+		if err != nil {
+			if debug {
+				fmt.Fprintf(os.Stderr, "[greywall:keyring] Failed to read %s from keyring (service=%s): %v\n", envName, lookup.Service, err)
+			}
+			continue
+		}
+
+		token := strings.TrimSpace(string(out))
+		if token == "" {
+			if debug {
+				fmt.Fprintf(os.Stderr, "[greywall:keyring] Empty value for %s from keyring, skipping\n", envName)
+			}
+			continue
+		}
+
+		envVars = append(envVars, envName+"="+token)
+		if debug {
+			fmt.Fprintf(os.Stderr, "[greywall:keyring] Injected %s from keyring (service=%s)\n", envName, lookup.Service)
+		}
+	}
+
+	return envVars
+}

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -83,10 +83,14 @@ func TestGetAgentProfile(t *testing.T) {
 		}
 
 		if profiles.IsToolchain(name) {
-			// Toolchain profiles should NOT have base paths
-			for _, p := range profile.Filesystem.AllowRead {
-				if p == "~/.gitconfig" {
-					t.Errorf("toolchain %q should not have base path ~/.gitconfig", name)
+			// Toolchain profiles should NOT have base paths inherited from BaseProfile.
+			// However, toolchains like gh/glab may explicitly include paths they need
+			// (e.g., ~/.gitconfig) in their own overlay, which is fine.
+			if name != "gh" && name != "glab" {
+				for _, p := range profile.Filesystem.AllowRead {
+					if p == "~/.gitconfig" {
+						t.Errorf("toolchain %q should not have base path ~/.gitconfig", name)
+					}
 				}
 			}
 		} else {

--- a/internal/profiles/registry.go
+++ b/internal/profiles/registry.go
@@ -7,6 +7,14 @@ import (
 	"github.com/GreyhavenHQ/greywall/internal/config"
 )
 
+// KeyringLookup defines how to retrieve a secret from the system keyring.
+// On Linux, this uses secret-tool to read from gnome-keyring via libsecret.
+type KeyringLookup struct {
+	// Service is the attribute value for "service" passed to secret-tool lookup.
+	// Example: "gh:github.com" retrieves the GitHub CLI OAuth token.
+	Service string
+}
+
 // AgentDef is everything needed to define a known agent or toolchain profile.
 // Each file in the agents/ subpackage creates one of these and passes it to
 // Register() via an init() function, so adding a new entry is a single
@@ -24,6 +32,13 @@ type AgentDef struct {
 	// Overlay returns the profile-specific config. For agents this is merged
 	// on top of BaseProfile(); for toolchains it is used as-is.
 	Overlay func() *config.Config
+
+	// KeyringSecrets maps environment variable names to keyring lookups.
+	// On Linux, greywall reads these from the host keyring at startup (before
+	// sandboxing) and injects them as environment variables. This avoids
+	// exposing the D-Bus session bus (and gnome-keyring) inside the sandbox.
+	// Ignored on macOS (keychain is accessible via file-based access).
+	KeyringSecrets map[string]KeyringLookup
 }
 
 var registry []AgentDef
@@ -82,6 +97,17 @@ func AvailableAgents() []string {
 	}
 	sort.Strings(agents)
 	return agents
+}
+
+// GetKeyringSecrets returns all keyring secret mappings for the given canonical name.
+// Returns nil if the profile has no keyring secrets.
+func GetKeyringSecrets(canonical string) map[string]KeyringLookup {
+	for _, def := range registry {
+		if def.Names[0] == canonical && len(def.KeyringSecrets) > 0 {
+			return def.KeyringSecrets
+		}
+	}
+	return nil
 }
 
 // AdHocCommands is the set of basic unix utilities that should not trigger

--- a/internal/profiles/toolchains/scm.go
+++ b/internal/profiles/toolchains/scm.go
@@ -13,6 +13,7 @@ func init() {
 			return &config.Config{
 				Filesystem: config.FilesystemConfig{
 					AllowRead: []string{
+						"~/.gitconfig", "~/.gitignore", "~/.config/git",
 						"~/.config/gh", "~/.cache/gh", "~/.local/share/gh", "~/.local/state/gh",
 						"~/.config/glab-cli", "~/.cache/glab-cli", "~/.local/share/glab-cli", "~/.local/state/glab-cli",
 					},
@@ -22,6 +23,12 @@ func init() {
 					},
 				},
 			}
+		},
+		// On Linux, gh stores its OAuth token in gnome-keyring via libsecret.
+		// The D-Bus session bus (and thus the keyring) is blocked inside the sandbox.
+		// Read the token on the host via secret-tool and inject it as GH_TOKEN.
+		KeyringSecrets: map[string]profiles.KeyringLookup{
+			"GH_TOKEN": {Service: "gh:github.com"},
 		},
 	})
 }

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -330,6 +330,12 @@ func PrintDependencyStatus() []string {
 		fmt.Println(CheckFail("xdg-dbus-proxy — optional, enables notify-send inside sandbox"))
 		steps = append(steps, suggestInstallDbusProxy())
 	}
+	if commandExists("secret-tool") {
+		fmt.Println(CheckOK("secret-tool (keyring credential injection for gh/glab)"))
+	} else {
+		fmt.Println(CheckFail("secret-tool — optional, injects keyring credentials (gh, glab) into sandbox"))
+		steps = append(steps, suggestInstallSecretTool())
+	}
 
 	// Network isolation (transparent proxy via tun2socks + network namespace)
 	if features.CanUseTransparentProxy() {
@@ -408,6 +414,25 @@ func suggestInstallDbusProxy() string {
 		return "sudo zypper install xdg-dbus-proxy"
 	default:
 		return "install xdg-dbus-proxy using your package manager"
+	}
+}
+
+func suggestInstallSecretTool() string {
+	switch {
+	case commandExists("apt-get"):
+		return "sudo apt install libsecret-tools"
+	case commandExists("dnf"):
+		return "sudo dnf install libsecret"
+	case commandExists("yum"):
+		return "sudo yum install libsecret"
+	case commandExists("pacman"):
+		return "sudo pacman -S libsecret"
+	case commandExists("apk"):
+		return "sudo apk add libsecret-tools"
+	case commandExists("zypper"):
+		return "sudo zypper install libsecret-tools"
+	default:
+		return "install libsecret-tools (provides secret-tool) using your package manager"
 	}
 }
 


### PR DESCRIPTION
## Summary

- On Linux, `gh` stores its OAuth token in gnome-keyring via libsecret. Since the D-Bus session bus is blocked inside the sandbox (#32), `gh` cannot access the keyring directly
- Greywall now reads the token on the host (before sandboxing) using `secret-tool` and injects it as `GH_TOKEN`
- Added `KeyringSecrets` field to `AgentDef` for profile-driven credential injection (env var to keyring service mapping)
- Added `~/.gitconfig` to gh/glab toolchain profile (required by `gh`)
- Added `secret-tool` status to `greywall check` with install suggestions
- Added `libsecret-tools` to CI workflow and install docs

Depends on #33

## Test plan

- [x] `greywall check` shows secret-tool status
- [x] `greywall --profile gh -- gh auth status` succeeds with injected GH_TOKEN
- [x] `greywall -- gh auth status` works when gh profile is auto-detected
- [x] Token is not injected if GH_TOKEN is already set in environment
- [x] Graceful fallback when secret-tool is not installed
- [x] Existing unit tests pass