### PR TITLE
fix: resolve symlinked dotfiles and allowRead paths in sandbox

### DIFF
--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -612,21 +612,35 @@ func buildDenyByDefaultMounts(cfg *config.Config, cwd string, dbusBridge *DbusBr
 			args = append(args, "--ro-bind", p, p)
 		}
 
-		// Shell config files in home (read-only, literal files)
+		// Shell config files in home (read-only)
+		// These may be symlinks (e.g., GNU Stow managed dotfiles), so resolve
+		// them and bind the real file at the symlink location.
 		shellConfigs := []string{".bashrc", ".bash_profile", ".profile", ".zshrc", ".zprofile", ".zshenv", ".inputrc"}
 		homeIntermedaryAdded := boundDirs[home]
 		for _, f := range shellConfigs {
 			p := filepath.Join(home, f)
-			if fileExists(p) && canMountOver(p) {
-				if !homeIntermedaryAdded {
-					for _, dir := range intermediaryDirs("/", home) {
-						if !boundDirs[dir] && !isSystemMountPoint(dir) {
-							boundDirs[dir] = true
-							args = append(args, "--dir", dir)
-						}
+			if !fileExists(p) {
+				continue
+			}
+			if !homeIntermedaryAdded {
+				for _, dir := range intermediaryDirs("/", home) {
+					if !boundDirs[dir] && !isSystemMountPoint(dir) {
+						boundDirs[dir] = true
+						args = append(args, "--dir", dir)
 					}
-					homeIntermedaryAdded = true
 				}
+				homeIntermedaryAdded = true
+			}
+			if isSymlink(p) {
+				// Resolve the symlink and bind the real file at the symlink path.
+				// This avoids bwrap following the symlink to a potentially
+				// unreachable target (e.g., ~/dotfiles/.zshrc via GNU Stow).
+				resolved, err := filepath.EvalSymlinks(p)
+				if err != nil || !fileExists(resolved) {
+					continue
+				}
+				args = append(args, "--ro-bind", resolved, p)
+			} else {
 				args = append(args, "--ro-bind", p, p)
 			}
 		}
@@ -635,60 +649,70 @@ func buildDenyByDefaultMounts(cfg *config.Config, cwd string, dbusBridge *DbusBr
 		homeCaches := []string{".cache", ".npm", ".cargo", ".rustup", ".local", ".config"}
 		for _, d := range homeCaches {
 			p := filepath.Join(home, d)
-			if fileExists(p) && canMountOver(p) {
-				if !homeIntermedaryAdded {
-					for _, dir := range intermediaryDirs("/", home) {
-						if !boundDirs[dir] && !isSystemMountPoint(dir) {
-							boundDirs[dir] = true
-							args = append(args, "--dir", dir)
-						}
+			if !fileExists(p) {
+				continue
+			}
+			if !homeIntermedaryAdded {
+				for _, dir := range intermediaryDirs("/", home) {
+					if !boundDirs[dir] && !isSystemMountPoint(dir) {
+						boundDirs[dir] = true
+						args = append(args, "--dir", dir)
 					}
-					homeIntermedaryAdded = true
 				}
+				homeIntermedaryAdded = true
+			}
+			if isSymlink(p) {
+				resolved, err := filepath.EvalSymlinks(p)
+				if err != nil || !fileExists(resolved) {
+					continue
+				}
+				args = append(args, "--ro-bind", resolved, p)
+			} else {
 				args = append(args, "--ro-bind", p, p)
 			}
 		}
 	}
 
 	// User-specified allowRead paths (read-only)
+	// Symlinks are resolved and the real file is bound at the symlink path,
+	// so bwrap doesn't follow the symlink to a potentially unreachable target.
 	if cfg != nil && cfg.Filesystem.AllowRead != nil {
 		boundPaths := make(map[string]bool)
 
+		bindReadPath := func(p string) {
+			if !fileExists(p) || strings.HasPrefix(p, "/dev/") || strings.HasPrefix(p, "/proc/") || boundPaths[p] {
+				return
+			}
+			// Resolve symlinks: bind the real file/dir at the symlink location
+			source := p
+			if isSymlink(p) {
+				resolved, err := filepath.EvalSymlinks(p)
+				if err != nil || !fileExists(resolved) {
+					return
+				}
+				source = resolved
+			}
+			boundPaths[p] = true
+			dirTarget := p
+			if !isDirectory(source) {
+				dirTarget = filepath.Dir(p)
+			}
+			for _, dir := range intermediaryDirs("/", dirTarget) {
+				if !isSystemMountPoint(dir) {
+					args = append(args, "--dir", dir)
+				}
+			}
+			args = append(args, "--ro-bind", source, p)
+		}
+
 		expandedPaths := ExpandGlobPatterns(cfg.Filesystem.AllowRead)
 		for _, p := range expandedPaths {
-			if fileExists(p) && canMountOver(p) &&
-				!strings.HasPrefix(p, "/dev/") && !strings.HasPrefix(p, "/proc/") && !boundPaths[p] {
-				boundPaths[p] = true
-				// Create intermediary dirs if needed.
-				// For files, only create dirs up to the parent to avoid
-				// creating a directory at the file's path.
-				dirTarget := p
-				if !isDirectory(p) {
-					dirTarget = filepath.Dir(p)
-				}
-				for _, dir := range intermediaryDirs("/", dirTarget) {
-					if !isSystemMountPoint(dir) {
-						args = append(args, "--dir", dir)
-					}
-				}
-				args = append(args, "--ro-bind", p, p)
-			}
+			bindReadPath(p)
 		}
 		for _, p := range cfg.Filesystem.AllowRead {
 			normalized := NormalizePath(p)
-			if !ContainsGlobChars(normalized) && fileExists(normalized) && canMountOver(normalized) &&
-				!strings.HasPrefix(normalized, "/dev/") && !strings.HasPrefix(normalized, "/proc/") && !boundPaths[normalized] {
-				boundPaths[normalized] = true
-				dirTarget := normalized
-				if !isDirectory(normalized) {
-					dirTarget = filepath.Dir(normalized)
-				}
-				for _, dir := range intermediaryDirs("/", dirTarget) {
-					if !isSystemMountPoint(dir) {
-						args = append(args, "--dir", dir)
-					}
-				}
-				args = append(args, "--ro-bind", normalized, normalized)
+			if !ContainsGlobChars(normalized) {
+				bindReadPath(normalized)
 			}
 		}
 	}

--- a/internal/sandbox/symlink_linux_test.go
+++ b/internal/sandbox/symlink_linux_test.go
@@ -23,52 +23,37 @@ func TestLinux_SymlinkedShellConfigReadable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check if any shell config is a symlink
-	shellConfigs := []string{".bashrc", ".bash_profile", ".profile", ".zshrc", ".zprofile", ".zshenv"}
-	var symlinkConfig string
-	for _, f := range shellConfigs {
-		p := filepath.Join(home, f)
-		if isSymlink(p) {
-			symlinkConfig = p
-			break
-		}
-	}
-	if symlinkConfig == "" {
-		// Create a symlinked shell config for testing
-		dotfilesDir := filepath.Join(workspace, "dotfiles")
-		if err := os.MkdirAll(dotfilesDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		realFile := filepath.Join(dotfilesDir, ".greywall-test-rc")
-		if err := os.WriteFile(realFile, []byte("# greywall symlink test\nexport GREYWALL_TEST=1\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		symlinkConfig = filepath.Join(home, ".greywall-test-rc")
-		if err := os.Symlink(realFile, symlinkConfig); err != nil {
-			t.Fatalf("failed to create test symlink: %v", err)
-		}
-		defer os.Remove(symlinkConfig)
+	// Create a symlinked shell config using one of the recognized names.
+	// Use .inputrc since it's unlikely to exist on CI runners.
+	configName := ".inputrc"
+	symlinkPath := filepath.Join(home, configName)
+
+	// Skip if .inputrc already exists (don't overwrite real config)
+	if fileExists(symlinkPath) {
+		t.Skipf("skipping: %s already exists", symlinkPath)
 	}
 
-	// Verify it's actually a symlink
-	if !isSymlink(symlinkConfig) {
-		t.Fatalf("expected %s to be a symlink", symlinkConfig)
+	// Create the real file inside the workspace
+	realFile := filepath.Join(workspace, "dotfiles", configName)
+	if err := os.MkdirAll(filepath.Dir(realFile), 0o750); err != nil {
+		t.Fatal(err)
 	}
+	if err := os.WriteFile(realFile, []byte("# greywall symlink test\nset editing-mode vi\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, symlinkPath); err != nil {
+		t.Fatalf("failed to create test symlink: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(symlinkPath) })
 
 	// Use deny-by-default mode (where buildDenyByDefaultMounts is used)
 	cfg := testConfigWithWorkspace(workspace)
 	cfg.Filesystem.DefaultDenyRead = boolPtr(true)
-	cfg.Filesystem.AllowRead = []string{symlinkConfig}
 
-	result := runUnderSandbox(t, cfg, "cat "+symlinkConfig, workspace)
+	result := runUnderSandbox(t, cfg, "cat "+symlinkPath, workspace)
 
 	assertAllowed(t, result)
-	if !strings.Contains(result.Stdout, "greywall") && !strings.Contains(result.Stdout, "export") {
-		// If it's the user's real config, just check it's non-empty
-		if result.Stdout == "" {
-			t.Error("expected to read symlinked config content, got empty output")
-		}
-	}
+	assertContains(t, result.Stdout, "greywall symlink test")
 }
 
 // TestLinux_SymlinkedAllowReadPath verifies that user-specified allowRead paths
@@ -81,7 +66,7 @@ func TestLinux_SymlinkedAllowReadPath(t *testing.T) {
 
 	// Create a real file and a symlink to it
 	realFile := filepath.Join(workspace, "real-data.txt")
-	if err := os.WriteFile(realFile, []byte("symlink-test-content"), 0o644); err != nil {
+	if err := os.WriteFile(realFile, []byte("symlink-test-content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	symlink := filepath.Join(workspace, "link-data.txt")
@@ -99,3 +84,33 @@ func TestLinux_SymlinkedAllowReadPath(t *testing.T) {
 	assertContains(t, result.Stdout, "symlink-test-content")
 }
 
+// TestLinux_SymlinkedAllowReadPathLegacyMode verifies that symlinked allowRead
+// paths work in legacy mode (--ro-bind / /) too.
+func TestLinux_SymlinkedAllowReadPathLegacyMode(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "bwrap")
+
+	workspace := createTempWorkspace(t)
+
+	realFile := filepath.Join(workspace, "real-data.txt")
+	if err := os.WriteFile(realFile, []byte("legacy-symlink-test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(workspace, "link-data.txt")
+	if err := os.Symlink(realFile, symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfigWithWorkspace(workspace)
+	// Legacy mode: defaultDenyRead=false (default from testConfig)
+
+	// In legacy mode, symlinks within the workspace should just work since
+	// --ro-bind / / carries the whole root filesystem (non-recursive bind
+	// still includes same-mount content).
+	result := runUnderSandbox(t, cfg, "cat "+symlink, workspace)
+
+	assertAllowed(t, result)
+	if !strings.Contains(result.Stdout, "legacy-symlink-test") {
+		t.Errorf("expected to read symlinked file content, got: %s", result.Stdout)
+	}
+}

--- a/internal/sandbox/symlink_linux_test.go
+++ b/internal/sandbox/symlink_linux_test.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLinux_SymlinkedShellConfigReadable verifies that symlinked dotfiles
+// (e.g., ~/.zshrc managed by GNU Stow) are readable inside the sandbox in
+// deny-by-default mode. Previously, canMountOver() rejected symlinks entirely,
+// causing bwrap to skip them.
+func TestLinux_SymlinkedShellConfigReadable(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "bwrap")
+
+	workspace := createTempWorkspace(t)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if any shell config is a symlink
+	shellConfigs := []string{".bashrc", ".bash_profile", ".profile", ".zshrc", ".zprofile", ".zshenv"}
+	var symlinkConfig string
+	for _, f := range shellConfigs {
+		p := filepath.Join(home, f)
+		if isSymlink(p) {
+			symlinkConfig = p
+			break
+		}
+	}
+	if symlinkConfig == "" {
+		// Create a symlinked shell config for testing
+		dotfilesDir := filepath.Join(workspace, "dotfiles")
+		if err := os.MkdirAll(dotfilesDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		realFile := filepath.Join(dotfilesDir, ".greywall-test-rc")
+		if err := os.WriteFile(realFile, []byte("# greywall symlink test\nexport GREYWALL_TEST=1\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		symlinkConfig = filepath.Join(home, ".greywall-test-rc")
+		if err := os.Symlink(realFile, symlinkConfig); err != nil {
+			t.Fatalf("failed to create test symlink: %v", err)
+		}
+		defer os.Remove(symlinkConfig)
+	}
+
+	// Verify it's actually a symlink
+	if !isSymlink(symlinkConfig) {
+		t.Fatalf("expected %s to be a symlink", symlinkConfig)
+	}
+
+	// Use deny-by-default mode (where buildDenyByDefaultMounts is used)
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = boolPtr(true)
+	cfg.Filesystem.AllowRead = []string{symlinkConfig}
+
+	result := runUnderSandbox(t, cfg, "cat "+symlinkConfig, workspace)
+
+	assertAllowed(t, result)
+	if !strings.Contains(result.Stdout, "greywall") && !strings.Contains(result.Stdout, "export") {
+		// If it's the user's real config, just check it's non-empty
+		if result.Stdout == "" {
+			t.Error("expected to read symlinked config content, got empty output")
+		}
+	}
+}
+
+// TestLinux_SymlinkedAllowReadPath verifies that user-specified allowRead paths
+// that are symlinks are resolved and accessible inside the sandbox.
+func TestLinux_SymlinkedAllowReadPath(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "bwrap")
+
+	workspace := createTempWorkspace(t)
+
+	// Create a real file and a symlink to it
+	realFile := filepath.Join(workspace, "real-data.txt")
+	if err := os.WriteFile(realFile, []byte("symlink-test-content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(workspace, "link-data.txt")
+	if err := os.Symlink(realFile, symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = boolPtr(true)
+	cfg.Filesystem.AllowRead = []string{symlink}
+
+	result := runUnderSandbox(t, cfg, "cat "+symlink, workspace)
+
+	assertAllowed(t, result)
+	assertContains(t, result.Stdout, "symlink-test-content")
+}
+


### PR DESCRIPTION
## Summary

Fixes #25 (dotfiles part, as reported by @johanfleury)

Users who manage dotfiles with **GNU Stow** or similar tools have `~/.gitconfig`, `~/.zshrc`, etc. as symlinks. In deny-by-default mode, `canMountOver()` rejected symlinks entirely, so these files were silently skipped and invisible inside the sandbox, causing `bwrap: Can't create file` errors.

- Shell config files (`.bashrc`, `.zshrc`, `.profile`, etc.) that are symlinks are now resolved: the real file is bound at the symlink path via `--ro-bind <resolved> <symlink-path>`
- Home tool caches (`.config`, `.cache`, `.npm`, etc.) get the same treatment
- User-specified `allowRead` paths that are symlinks are resolved and bound correctly, with a refactored `bindReadPath` helper to reduce duplication

## Test plan

- [x] Integration test: symlinked shell config is readable in deny-by-default mode
- [x] Integration test: symlinked `allowRead` path is readable in deny-by-default mode
- [ ] Manual test with GNU Stow managed dotfiles