### PR TITLE
feat: forward host localhost ports into Linux sandbox

### DIFF
--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -39,6 +39,7 @@ var (
 	dnsAddr       string
 	cmdString     string
 	exposePorts   []string
+	forwardPorts  []string
 	exitCode      int
 	showVersion   bool
 	linuxFeatures bool
@@ -79,6 +80,7 @@ Examples:
   greywall -c "echo hello && ls"                                # Run with shell expansion
   greywall --settings config.json npm install
   greywall -p 3000 -c "npm run dev"                             # Expose port 3000
+  greywall -f 5432 -- psql -h localhost                          # Forward host port into sandbox
   greywall --learning -- opencode                                # Learn filesystem needs
 
 Configuration file format:
@@ -109,6 +111,7 @@ Configuration file format:
 	rootCmd.Flags().StringVar(&httpProxyURL, "http-proxy", "", "HTTP CONNECT proxy URL (default: http://localhost:43051)")
 	rootCmd.Flags().StringVarP(&cmdString, "c", "c", "", "Run command string directly (like sh -c)")
 	rootCmd.Flags().StringArrayVarP(&exposePorts, "port", "p", nil, "Expose port for inbound connections (can be used multiple times)")
+	rootCmd.Flags().StringArrayVarP(&forwardPorts, "forward", "f", nil, "Forward host localhost port into sandbox (can be used multiple times)")
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version information")
 	rootCmd.Flags().BoolVar(&linuxFeatures, "linux-features", false, "Show available Linux security features and exit")
 	rootCmd.Flags().BoolVar(&learning, "learning", false, "Run in learning mode: trace filesystem access and generate a config profile")
@@ -173,6 +176,19 @@ func runCommand(cmd *cobra.Command, args []string) error {
 
 	if debug && len(ports) > 0 {
 		fmt.Fprintf(os.Stderr, "[greywall] Exposing ports: %v\n", ports)
+	}
+
+	var fwdPorts []int
+	for _, p := range forwardPorts {
+		port, err := strconv.Atoi(p)
+		if err != nil || port < 1 || port > 65535 {
+			return fmt.Errorf("invalid forward port: %s", p)
+		}
+		fwdPorts = append(fwdPorts, port)
+	}
+
+	if debug && len(fwdPorts) > 0 {
+		fmt.Fprintf(os.Stderr, "[greywall] Forwarding host ports: %v\n", fwdPorts)
 	}
 
 	// Load config: settings file > default path > default config
@@ -311,6 +327,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 	if debug {
 		fmt.Fprintf(os.Stderr, "[greywall] Auto-set proxy credentials to %q:proxy\n", proxyUser)
+	}
+
+	// Merge CLI forward ports into config
+	if len(fwdPorts) > 0 {
+		cfg.Network.ForwardPorts = append(cfg.Network.ForwardPorts, fwdPorts...)
 	}
 
 	// Learning mode setup

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -19,13 +19,37 @@ When you allow domains, greywall:
 ### Localhost controls
 
 - `allowLocalBinding`: lets a sandboxed process *listen* on local ports (e.g. dev servers).
-- `allowLocalOutbound`: lets a sandboxed process connect to `localhost` services (e.g. Redis/Postgres on your machine).
+- `allowLocalOutbound`: lets a sandboxed process connect to `localhost` services (macOS only).
 - `-p/--port`: exposes inbound ports so things outside the sandbox can reach your server.
+- `-f/--forward`: forwards a host localhost port into the sandbox (Linux only).
+- `forwardPorts`: config equivalent of `-f` for specifying ports to forward.
 
 These are separate on purpose. A typical safe default for dev servers is:
 
 - allow binding + expose just the needed port(s)
 - disallow localhost outbound unless you explicitly need it
+
+### Port forwarding: platform differences
+
+On macOS, the sandbox shares the host network stack, so `allowLocalOutbound: true` is enough for the sandboxed process to connect to any host localhost service.
+
+On Linux, the sandbox runs in an isolated network namespace (bubblewrap `--unshare-net`). The host's `localhost` is not reachable from inside the sandbox. To connect to a specific host service, you must explicitly forward its port:
+
+| Feature | macOS | Linux |
+|---------|-------|-------|
+| Sandbox connects to host `localhost` | `allowLocalOutbound: true` | `-f <port>` or `forwardPorts: [port]` |
+| Host connects to sandbox port | `-p <port>` | `-p <port>` |
+| Sandbox listens on local port | `allowLocalBinding: true` | `allowLocalBinding: true` |
+
+Example: connecting to a local database on port 5432 from a sandboxed command:
+
+```bash
+# macOS (allowLocalOutbound in config is sufficient)
+greywall -- psql -h localhost
+
+# Linux (must forward the specific port)
+greywall -f 5432 -- psql -h localhost
+```
 
 ## Filesystem model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,8 @@ Greywall routes all network traffic through an external SOCKS5 proxy. Domain fil
 | `allowUnixSockets` | List of allowed Unix socket paths (macOS) |
 | `allowAllUnixSockets` | Allow all Unix sockets |
 | `allowLocalBinding` | Allow binding to local ports |
-| `allowLocalOutbound` | Allow outbound connections to localhost, e.g., local DBs (defaults to `allowLocalBinding` if not set) |
+| `allowLocalOutbound` | Allow outbound connections to localhost, e.g., local DBs (defaults to `allowLocalBinding` if not set; macOS only) |
+| `forwardPorts` | Host localhost ports to forward into the sandbox (Linux only; array of integers) |
 
 ## Filesystem Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type NetworkConfig struct {
 	AllowAllUnixSockets bool     `json:"allowAllUnixSockets,omitempty"`
 	AllowLocalBinding   bool     `json:"allowLocalBinding,omitempty"`
 	AllowLocalOutbound  *bool    `json:"allowLocalOutbound,omitempty"` // If nil, defaults to AllowLocalBinding value
+	ForwardPorts        []int    `json:"forwardPorts,omitempty"`       // Host localhost ports to forward into sandbox
 }
 
 // FilesystemConfig defines filesystem restrictions.
@@ -445,6 +446,9 @@ func Merge(base, override *Config) *Config {
 
 			// Pointer fields: override wins if set, otherwise base
 			AllowLocalOutbound: mergeOptionalBool(base.Network.AllowLocalOutbound, override.Network.AllowLocalOutbound),
+
+			// Append slices
+			ForwardPorts: mergeIntSlice(base.Network.ForwardPorts, override.Network.ForwardPorts),
 		},
 
 		Filesystem: FilesystemConfig{
@@ -508,6 +512,33 @@ func mergeStrings(base, override []string) []string {
 		if !seen[s] {
 			seen[s] = true
 			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// mergeIntSlice appends two int slices, removing duplicates.
+func mergeIntSlice(base, override []int) []int {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	seen := make(map[int]bool, len(base))
+	result := make([]int, 0, len(base)+len(override))
+
+	for _, v := range base {
+		if !seen[v] {
+			seen[v] = true
+			result = append(result, v)
+		}
+	}
+	for _, v := range override {
+		if !seen[v] {
+			seen[v] = true
+			result = append(result, v)
 		}
 	}
 	return result

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -668,6 +668,60 @@ func TestMergeSSHConfig(t *testing.T) {
 	})
 }
 
+func TestMergeForwardPorts(t *testing.T) {
+	t.Run("merge forward ports deduplicates", func(t *testing.T) {
+		base := &Config{
+			Network: NetworkConfig{
+				ForwardPorts: []int{5432, 6379},
+			},
+		}
+		override := &Config{
+			Network: NetworkConfig{
+				ForwardPorts: []int{6379, 8080},
+			},
+		}
+		result := Merge(base, override)
+
+		if len(result.Network.ForwardPorts) != 3 {
+			t.Errorf("expected 3 forward ports, got %d: %v", len(result.Network.ForwardPorts), result.Network.ForwardPorts)
+		}
+		expected := map[int]bool{5432: true, 6379: true, 8080: true}
+		for _, p := range result.Network.ForwardPorts {
+			if !expected[p] {
+				t.Errorf("unexpected port %d in merged result", p)
+			}
+		}
+	})
+
+	t.Run("merge forward ports empty base", func(t *testing.T) {
+		base := &Config{}
+		override := &Config{
+			Network: NetworkConfig{
+				ForwardPorts: []int{3000},
+			},
+		}
+		result := Merge(base, override)
+
+		if len(result.Network.ForwardPorts) != 1 || result.Network.ForwardPorts[0] != 3000 {
+			t.Errorf("expected [3000], got %v", result.Network.ForwardPorts)
+		}
+	})
+
+	t.Run("merge forward ports empty override", func(t *testing.T) {
+		base := &Config{
+			Network: NetworkConfig{
+				ForwardPorts: []int{3000},
+			},
+		}
+		override := &Config{}
+		result := Merge(base, override)
+
+		if len(result.Network.ForwardPorts) != 1 || result.Network.ForwardPorts[0] != 3000 {
+			t.Errorf("expected [3000], got %v", result.Network.ForwardPorts)
+		}
+	})
+}
+
 func TestValidateProxyURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -540,6 +540,153 @@ func TestLinux_GlobPatternAllowsWriteToMatchingFile(t *testing.T) {
 }
 
 // ============================================================================
+// Forward Bridge Tests
+// ============================================================================
+
+// TestLinux_ForwardBridgeCreatesSocketDir verifies that NewForwardBridge creates
+// sockets in a dedicated subdirectory, not directly in /tmp.
+func TestLinux_ForwardBridgeCreatesSocketDir(t *testing.T) {
+	bridge, err := NewForwardBridge([]int{19876}, false)
+	if err != nil {
+		t.Fatalf("NewForwardBridge failed: %v", err)
+	}
+	defer bridge.Cleanup()
+
+	if len(bridge.SocketPaths) != 1 {
+		t.Fatalf("expected 1 socket path, got %d", len(bridge.SocketPaths))
+	}
+
+	socketPath := bridge.SocketPaths[0]
+	dir := filepath.Dir(socketPath)
+
+	// Socket dir should be a greywall-fwd-* subdirectory, not /tmp itself
+	if dir == os.TempDir() {
+		t.Errorf("socket should be in a subdirectory, not directly in %s: %s", os.TempDir(), socketPath)
+	}
+	if !strings.Contains(dir, "greywall-fwd-") {
+		t.Errorf("socket directory should contain 'greywall-fwd-': %s", dir)
+	}
+
+	// Directory should exist
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Errorf("socket directory should exist: %s", dir)
+	}
+}
+
+// TestLinux_ForwardBridgeCleanup verifies that Cleanup removes sockets and directory.
+func TestLinux_ForwardBridgeCleanup(t *testing.T) {
+	bridge, err := NewForwardBridge([]int{19877}, false)
+	if err != nil {
+		t.Fatalf("NewForwardBridge failed: %v", err)
+	}
+
+	socketPath := bridge.SocketPaths[0]
+	dir := filepath.Dir(socketPath)
+
+	bridge.Cleanup()
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("socket directory should be removed after cleanup: %s", dir)
+	}
+}
+
+// TestLinux_ForwardBridgeMultiplePorts verifies multiple ports create separate sockets.
+func TestLinux_ForwardBridgeMultiplePorts(t *testing.T) {
+	bridge, err := NewForwardBridge([]int{19878, 19879, 19880}, false)
+	if err != nil {
+		t.Fatalf("NewForwardBridge failed: %v", err)
+	}
+	defer bridge.Cleanup()
+
+	if len(bridge.SocketPaths) != 3 {
+		t.Fatalf("expected 3 socket paths, got %d", len(bridge.SocketPaths))
+	}
+	if len(bridge.Ports) != 3 {
+		t.Fatalf("expected 3 ports, got %d", len(bridge.Ports))
+	}
+
+	// All sockets should be in the same directory
+	dir := filepath.Dir(bridge.SocketPaths[0])
+	for _, sp := range bridge.SocketPaths[1:] {
+		if filepath.Dir(sp) != dir {
+			t.Errorf("all sockets should be in the same directory: %s vs %s", dir, filepath.Dir(sp))
+		}
+	}
+}
+
+// TestLinux_ForwardBridgeEmptyPorts returns nil for empty ports.
+func TestLinux_ForwardBridgeEmptyPorts(t *testing.T) {
+	bridge, err := NewForwardBridge([]int{}, false)
+	if err != nil {
+		t.Fatalf("NewForwardBridge failed: %v", err)
+	}
+	if bridge != nil {
+		t.Errorf("expected nil bridge for empty ports")
+	}
+}
+
+// TestLinux_ReverseBridgeCreatesSocketDir verifies that NewReverseBridge also uses
+// a dedicated subdirectory (same fix applied to both bridges).
+func TestLinux_ReverseBridgeCreatesSocketDir(t *testing.T) {
+	bridge, err := NewReverseBridge([]int{19881}, false)
+	if err != nil {
+		t.Fatalf("NewReverseBridge failed: %v", err)
+	}
+	defer bridge.Cleanup()
+
+	if len(bridge.SocketPaths) != 1 {
+		t.Fatalf("expected 1 socket path, got %d", len(bridge.SocketPaths))
+	}
+
+	dir := filepath.Dir(bridge.SocketPaths[0])
+
+	if dir == os.TempDir() {
+		t.Errorf("socket should be in a subdirectory, not directly in %s", os.TempDir())
+	}
+	if !strings.Contains(dir, "greywall-rev-") {
+		t.Errorf("socket directory should contain 'greywall-rev-': %s", dir)
+	}
+}
+
+// TestLinux_ForwardBridgeConnectsToHost verifies that the forward bridge can
+// relay connections from the sandbox to a host localhost port.
+func TestLinux_ForwardBridgeConnectsToHost(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "socat")
+	skipIfCommandNotFound(t, "curl")
+
+	// Start a simple HTTP server on a random port using socat
+	// socat will respond with a fixed string to any connection
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Network.ForwardPorts = []int{19999}
+
+	// Start a listener on port 19999 that responds with "FORWARD_OK"
+	listener := exec.Command("socat", //nolint:gosec
+		"TCP-LISTEN:19999,fork,reuseaddr",
+		`EXEC:'echo HTTP/1.0 200 OK\r\n\r\nFORWARD_OK'`,
+	)
+	if err := listener.Start(); err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	// Give listener time to start
+	time.Sleep(200 * time.Millisecond)
+
+	// Run curl inside the sandbox targeting localhost:19999
+	result := runUnderSandboxWithTimeout(t, cfg,
+		"curl -s --connect-timeout 3 --max-time 5 http://localhost:19999",
+		workspace, 15*time.Second)
+
+	assertAllowed(t, result)
+	assertContains(t, result.Stdout, "FORWARD_OK")
+}
+
+// ============================================================================
 // Helper functions
 // ============================================================================
 

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -236,14 +236,18 @@ func NewReverseBridge(ports []int, debug bool) (*ReverseBridge, error) {
 	}
 	socketID := hex.EncodeToString(id)
 
-	tmpDir := os.TempDir()
+	socketDir := filepath.Join(os.TempDir(), fmt.Sprintf("greywall-rev-%s", socketID))
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create reverse bridge socket directory: %w", err)
+	}
+
 	bridge := &ReverseBridge{
 		Ports: ports,
 		debug: debug,
 	}
 
 	for _, port := range ports {
-		socketPath := filepath.Join(tmpDir, fmt.Sprintf("greywall-rev-%d-%s.sock", port, socketID))
+		socketPath := filepath.Join(socketDir, fmt.Sprintf("%d.sock", port))
 		bridge.SocketPaths = append(bridge.SocketPaths, socketPath)
 
 		// Start reverse bridge: TCP listen on host port -> Unix socket
@@ -280,13 +284,101 @@ func (b *ReverseBridge) Cleanup() {
 		}
 	}
 
-	// Clean up socket files
+	// Clean up socket files and directory
 	for _, socketPath := range b.SocketPaths {
 		_ = os.Remove(socketPath)
+	}
+	if len(b.SocketPaths) > 0 {
+		_ = os.Remove(filepath.Dir(b.SocketPaths[0]))
 	}
 
 	if b.debug {
 		fmt.Fprintf(os.Stderr, "[greywall:linux] Reverse bridges cleaned up\n")
+	}
+}
+
+// ForwardBridge bridges host localhost ports into the sandbox via Unix sockets.
+// Host side: socat listens on a Unix socket and forwards to localhost:PORT.
+// Sandbox side: socat listens on localhost:PORT and forwards through the Unix socket.
+type ForwardBridge struct {
+	Ports       []int
+	SocketPaths []string // Unix socket paths for each port
+	processes   []*exec.Cmd
+	debug       bool
+}
+
+// NewForwardBridge creates Unix socket bridges for outbound localhost connections.
+// Host listens on Unix sockets and forwards to localhost ports on the host.
+func NewForwardBridge(ports []int, debug bool) (*ForwardBridge, error) {
+	if len(ports) == 0 {
+		return nil, nil
+	}
+
+	if _, err := exec.LookPath("socat"); err != nil {
+		return nil, fmt.Errorf("socat is required on Linux but not found: %w", err)
+	}
+
+	id := make([]byte, 8)
+	if _, err := rand.Read(id); err != nil {
+		return nil, fmt.Errorf("failed to generate socket ID: %w", err)
+	}
+	socketID := hex.EncodeToString(id)
+
+	socketDir := filepath.Join(os.TempDir(), fmt.Sprintf("greywall-fwd-%s", socketID))
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create forward bridge socket directory: %w", err)
+	}
+
+	bridge := &ForwardBridge{
+		Ports: ports,
+		debug: debug,
+	}
+
+	for _, port := range ports {
+		socketPath := filepath.Join(socketDir, fmt.Sprintf("%d.sock", port))
+		bridge.SocketPaths = append(bridge.SocketPaths, socketPath)
+
+		// Start forward bridge: Unix socket listen -> TCP connect to host localhost:port
+		args := []string{
+			fmt.Sprintf("UNIX-LISTEN:%s,fork,reuseaddr", socketPath),
+			fmt.Sprintf("TCP:127.0.0.1:%d", port),
+		}
+		proc := exec.Command("socat", args...) //nolint:gosec // args constructed from trusted input
+		if debug {
+			fmt.Fprintf(os.Stderr, "[greywall:linux] Starting forward bridge for port %d: socat %s\n", port, strings.Join(args, " "))
+		}
+		if err := proc.Start(); err != nil {
+			bridge.Cleanup()
+			return nil, fmt.Errorf("failed to start forward bridge for port %d: %w", port, err)
+		}
+		bridge.processes = append(bridge.processes, proc)
+	}
+
+	if debug {
+		fmt.Fprintf(os.Stderr, "[greywall:linux] Forward bridges ready for ports: %v\n", ports)
+	}
+
+	return bridge, nil
+}
+
+// Cleanup stops the forward bridge processes and removes socket files.
+func (b *ForwardBridge) Cleanup() {
+	for _, proc := range b.processes {
+		if proc != nil && proc.Process != nil {
+			_ = proc.Process.Kill()
+			_ = proc.Wait()
+		}
+	}
+
+	for _, socketPath := range b.SocketPaths {
+		_ = os.Remove(socketPath)
+	}
+	if len(b.SocketPaths) > 0 {
+		_ = os.Remove(filepath.Dir(b.SocketPaths[0]))
+	}
+
+	if b.debug {
+		fmt.Fprintf(os.Stderr, "[greywall:linux] Forward bridges cleaned up\n")
 	}
 }
 
@@ -734,8 +826,8 @@ func isSystemMountPoint(path string) bool {
 
 // WrapCommandLinux wraps a command with Linux bubblewrap sandbox.
 // It uses available security features (Landlock, seccomp) with graceful fallback.
-func WrapCommandLinux(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, dbusBridge *DbusBridge, tun2socksPath string, debug bool) (string, error) {
-	return WrapCommandLinuxWithOptions(cfg, command, proxyBridge, dnsBridge, reverseBridge, dbusBridge, tun2socksPath, LinuxSandboxOptions{
+func WrapCommandLinux(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, forwardBridge *ForwardBridge, dbusBridge *DbusBridge, tun2socksPath string, debug bool) (string, error) {
+	return WrapCommandLinuxWithOptions(cfg, command, proxyBridge, dnsBridge, reverseBridge, forwardBridge, dbusBridge, tun2socksPath, LinuxSandboxOptions{
 		UseLandlock: true, // Enabled by default, will fall back if not available
 		UseSeccomp:  true, // Enabled by default
 		UseEBPF:     true, // Enabled by default if available
@@ -744,7 +836,7 @@ func WrapCommandLinux(cfg *config.Config, command string, proxyBridge *ProxyBrid
 }
 
 // WrapCommandLinuxWithOptions wraps a command with configurable sandbox options.
-func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, dbusBridge *DbusBridge, tun2socksPath string, opts LinuxSandboxOptions) (string, error) {
+func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, forwardBridge *ForwardBridge, dbusBridge *DbusBridge, tun2socksPath string, opts LinuxSandboxOptions) (string, error) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		return "", fmt.Errorf("bubblewrap (bwrap) is required on Linux but not found: %w", err)
 	}
@@ -1090,11 +1182,27 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		}
 	}
 
-	// Bind reverse socket directory if needed (sockets created inside sandbox)
-	if reverseBridge != nil && len(reverseBridge.SocketPaths) > 0 {
-		// Get the temp directory containing the reverse sockets
-		tmpDir := filepath.Dir(reverseBridge.SocketPaths[0])
-		bwrapArgs = append(bwrapArgs, "--bind", tmpDir, tmpDir)
+	// Bind bridge socket directories into the sandbox.
+	// Bridges use unique subdirectories under /tmp (e.g. /tmp/greywall-rev-xxx/)
+	// so bind-mounting them doesn't overwrite --tmpfs /tmp (which would break tun2socks).
+	bridgeSocketDirs := make(map[string]bool)
+	if reverseBridge != nil {
+		for _, sp := range reverseBridge.SocketPaths {
+			dir := filepath.Dir(sp)
+			if !bridgeSocketDirs[dir] {
+				bridgeSocketDirs[dir] = true
+				bwrapArgs = append(bwrapArgs, "--bind", dir, dir)
+			}
+		}
+	}
+	if forwardBridge != nil {
+		for _, sp := range forwardBridge.SocketPaths {
+			dir := filepath.Dir(sp)
+			if !bridgeSocketDirs[dir] {
+				bridgeSocketDirs[dir] = true
+				bwrapArgs = append(bwrapArgs, "--bind", dir, dir)
+			}
+		}
 	}
 
 	// Get greywall executable path for Landlock wrapper
@@ -1207,6 +1315,21 @@ export no_proxy=localhost,127.0.0.1
 				socketPath, port,
 			)
 			fmt.Fprintf(&innerScript, "REV_%d_PID=$!\n", port)
+		}
+		innerScript.WriteString("\n")
+	}
+
+	// Set up forward (outbound localhost) socat listeners inside the sandbox
+	if forwardBridge != nil && len(forwardBridge.Ports) > 0 {
+		innerScript.WriteString("\n# Start forward bridge listeners for outbound localhost connections\n")
+		for i, port := range forwardBridge.Ports {
+			socketPath := forwardBridge.SocketPaths[i]
+			// Listen on localhost:port inside the sandbox, forward to Unix socket -> host localhost:port
+			fmt.Fprintf(&innerScript,
+				"socat TCP-LISTEN:%d,fork,reuseaddr,bind=127.0.0.1 UNIX-CONNECT:%s >/dev/null 2>&1 &\n",
+				port, socketPath,
+			)
+			fmt.Fprintf(&innerScript, "FWD_%d_PID=$!\n", port)
 		}
 		innerScript.WriteString("\n")
 	}

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -27,6 +27,20 @@ type ReverseBridge struct {
 	SocketPaths []string
 }
 
+// ForwardBridge is a stub for non-Linux platforms.
+type ForwardBridge struct {
+	Ports       []int
+	SocketPaths []string
+}
+
+// NewForwardBridge returns an error on non-Linux platforms.
+func NewForwardBridge(ports []int, debug bool) (*ForwardBridge, error) {
+	return nil, fmt.Errorf("forward bridge not available on this platform")
+}
+
+// Cleanup is a no-op on non-Linux platforms.
+func (b *ForwardBridge) Cleanup() {}
+
 // DbusBridge is a stub for non-Linux platforms.
 type DbusBridge struct {
 	SocketPath string
@@ -76,12 +90,12 @@ func NewReverseBridge(ports []int, debug bool) (*ReverseBridge, error) {
 func (b *ReverseBridge) Cleanup() {}
 
 // WrapCommandLinux returns an error on non-Linux platforms.
-func WrapCommandLinux(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, dbusBridge *DbusBridge, tun2socksPath string, debug bool) (string, error) {
+func WrapCommandLinux(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, forwardBridge *ForwardBridge, dbusBridge *DbusBridge, tun2socksPath string, debug bool) (string, error) {
 	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // WrapCommandLinuxWithOptions returns an error on non-Linux platforms.
-func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, dbusBridge *DbusBridge, tun2socksPath string, opts LinuxSandboxOptions) (string, error) {
+func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge *ProxyBridge, dnsBridge *DnsBridge, reverseBridge *ReverseBridge, forwardBridge *ForwardBridge, dbusBridge *DbusBridge, tun2socksPath string, opts LinuxSandboxOptions) (string, error) {
 	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -16,6 +16,7 @@ type Manager struct {
 	proxyBridge   *ProxyBridge
 	dnsBridge     *DnsBridge
 	reverseBridge *ReverseBridge
+	forwardBridge *ForwardBridge
 	dbusBridge    *DbusBridge
 	tun2socksPath string // path to extracted tun2socks binary on host
 	exposedPorts  []int
@@ -183,6 +184,26 @@ func (m *Manager) Initialize() error {
 			m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
 		}
 
+		// Set up forward bridge for localhost outbound (sandbox -> host localhost ports)
+		if len(m.config.Network.ForwardPorts) > 0 && features.CanUnshareNet {
+			forwardBridge, err := NewForwardBridge(m.config.Network.ForwardPorts, m.debug)
+			if err != nil {
+				if m.proxyBridge != nil {
+					m.proxyBridge.Cleanup()
+				}
+				if m.reverseBridge != nil {
+					m.reverseBridge.Cleanup()
+				}
+				if m.tun2socksPath != "" {
+					_ = os.Remove(m.tun2socksPath)
+				}
+				return fmt.Errorf("failed to initialize forward bridge: %w", err)
+			}
+			m.forwardBridge = forwardBridge
+		} else if len(m.config.Network.ForwardPorts) > 0 && m.debug {
+			m.logDebug("Skipping forward bridge (no network namespace, ports accessible directly)")
+		}
+
 		// Set up filtered D-Bus proxy for notify-send support
 		// Returns nil gracefully if xdg-dbus-proxy is not installed
 		m.dbusBridge = NewDbusBridge(m.debug)
@@ -227,7 +248,7 @@ func (m *Manager) WrapCommand(command string) (string, error) {
 		if m.learning {
 			return m.wrapCommandLearning(command)
 		}
-		return WrapCommandLinux(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.dbusBridge, m.tun2socksPath, m.debug)
+		return WrapCommandLinux(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.forwardBridge, m.dbusBridge, m.tun2socksPath, m.debug)
 	default:
 		return "", fmt.Errorf("unsupported platform: %s", plat)
 	}
@@ -245,7 +266,7 @@ func (m *Manager) wrapCommandLearning(command string) (string, error) {
 
 	m.logDebug("Strace log file: %s", m.straceLogPath)
 
-	return WrapCommandLinuxWithOptions(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.dbusBridge, m.tun2socksPath, LinuxSandboxOptions{
+	return WrapCommandLinuxWithOptions(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.forwardBridge, m.dbusBridge, m.tun2socksPath, LinuxSandboxOptions{
 		UseLandlock:   false, // Disabled: seccomp blocks ptrace which strace needs
 		UseSeccomp:    false, // Disabled: conflicts with strace
 		UseEBPF:       false,
@@ -280,6 +301,9 @@ func (m *Manager) Cleanup() {
 
 	if m.dbusBridge != nil {
 		m.dbusBridge.Cleanup()
+	}
+	if m.forwardBridge != nil {
+		m.forwardBridge.Cleanup()
 	}
 	if m.reverseBridge != nil {
 		m.reverseBridge.Cleanup()


### PR DESCRIPTION
Closes #42

## Summary

- Add `-f/--forward <port>` CLI flag and `forwardPorts` config field to forward host localhost ports into the Linux sandbox
- Implement `ForwardBridge` using the same socat Unix socket relay pattern as the existing `ProxyBridge`, `DnsBridge`, and `ReverseBridge`
- Fix bridge socket placement: all bridge sockets now use dedicated subdirectories (`/tmp/greywall-fwd-xxx/`, `/tmp/greywall-rev-xxx/`) instead of being placed directly in `/tmp`, which prevented `--bind /tmp /tmp` from overwriting the `--tmpfs /tmp` mount and breaking tun2socks

## How it works

On Linux, `--unshare-net` creates an isolated network namespace where `localhost` is separate from the host. The forward bridge tunnels through a Unix socket:

1. **Host side**: socat listens on a Unix socket, forwards to `localhost:PORT` on the host
2. **Sandbox side**: socat listens on `localhost:PORT` inside the sandbox, forwards through the Unix socket

This is the reverse direction of the existing `ReverseBridge` (which handles `-p/--port` for inbound connections).

On macOS, this is unnecessary since `allowLocalOutbound: true` works natively (no network namespace isolation).

## Usage

```bash
# CLI flag
greywall -f 5432 -- psql -h localhost

# Config file
{ "forwardPorts": [5432, 6379] }

# Multiple ports
greywall -f 5432 -f 6379 -- my-app
```

## Test plan

- [x] `go test ./...` passes
- [x] `greywall -f 42000 -- curl localhost:42000` connects to host service
- [x] `greywall -f 42000 -- curl https://example.com` internet still works (no /tmp mount conflict)
- [x] `greywall -p 3000 -c "python3 -m http.server 3000"` reverse bridge still works