### PR TITLE
fix: allow CoreAudio Mach IPC services in macOS Seatbelt profile

### DIFF
--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -445,6 +445,8 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 ; Mach IPC - specific services only
 (allow mach-lookup
   (global-name "com.apple.audio.systemsoundserver")
+  (global-name "com.apple.audio.audiohald")
+  (global-name "com.apple.audio.AudioComponentRegistrar")
   (global-name "com.apple.distributed_notifications@Uv3")
   (global-name "com.apple.FontObjectsServer")
   (global-name "com.apple.fonts")


### PR DESCRIPTION
## Summary

- Adds `com.apple.audio.audiohald` and `com.apple.audio.AudioComponentRegistrar` to the allowed Mach IPC services in the macOS Seatbelt sandbox profile.
- Without these services, sandboxed commands on macOS cannot produce audio output — CoreAudio fails silently when the HAL daemon and component registrar are unreachable.

## Motivation

I use [PeonPing](https://github.com/PeonPing/peon-ping) with sound packs from [openpeon.com/packs](https://openpeon.com/packs) inside a greywall sandbox. Audio playback was completely broken on macOS because the Seatbelt profile blocked the Mach IPC lookups that CoreAudio requires.

## What changed

In `internal/sandbox/macos.go`, two Mach service names are added to the existing `mach-lookup` allow list:

- **`com.apple.audio.audiohald`** — the Core Audio HAL daemon, which manages audio hardware access
- **`com.apple.audio.AudioComponentRegistrar`** — registers and resolves audio components (codecs, effects, drivers)

These join the already-allowed `com.apple.audio.systemsoundserver`.

## Transparency notice

This change was AI-generated. I do not fully understand the security implications of exposing these additional Mach IPC services inside the sandbox. Reviewers should evaluate whether allowing these services introduces any sandbox escape vectors or unintended privilege escalation before merging.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)