### PR TITLE
fix: isolate /run with tmpfs and recreate /var/run symlinks in sandbox

### DIFF
--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -743,6 +743,21 @@ func buildDenyByDefaultMounts(cfg *config.Config, cwd string, dbusBridge *DbusBr
 		}
 	}
 
+	// /var: on modern distros, /var/run -> /run and /var/lock -> /run/lock.
+	// Many programs (e.g., virsh, systemctl) use /var/run paths.
+	// We recreate these symlinks so they resolve correctly inside the sandbox.
+	if fileExists("/var") {
+		args = append(args, "--dir", "/var")
+		for _, sub := range []string{"/var/run", "/var/lock"} {
+			if isSymlink(sub) {
+				target, err := os.Readlink(sub)
+				if err == nil {
+					args = append(args, "--symlink", target, sub)
+				}
+			}
+		}
+	}
+
 	// /run: use an empty tmpfs and selectively mount only what's needed.
 	// Mounting all of /run exposes dangerous host sockets (Docker, Podman,
 	// containerd, libvirt, etc.) that allow sandbox escape even when


### PR DESCRIPTION
## Summary

This PR includes two fixes for `/run` handling in the Linux sandbox:

1. **Isolate `/run` with tmpfs to prevent sandbox escape** (d1afb06) - Replace blanket `--ro-bind /run` with `--tmpfs /run` and selectively mount only what's needed. Previously, host sockets (Docker, Podman, containerd, libvirt) were accessible inside the sandbox, allowing full escape via Unix socket connections which bypass read-only mount restrictions.

2. **Recreate `/var/run` and `/var/lock` symlinks** (d7b3404) - On modern Linux distros, `/var/run -> /run` and `/var/lock -> /run/lock`. Many programs (virsh, systemctl, etc.) hardcode `/var/run` paths and fail without these symlinks. Follows the same pattern already used for `/bin -> usr/bin`, `/lib -> usr/lib`, etc.

Fixes #55
Fixes #53

## Test plan

- [x] `./greywall -- docker ps` fails to connect (socket no longer exposed)
- [x] `./greywall -- ls /var/run/` resolves correctly inside sandbox
- [x] `./greywall -- virsh -c qemu:///system list` connects successfully (with libvirt allowRead/allowWrite config)
- [x] `make test` passes
- [ ] Verify on a distro where `/var/run` is a real directory (not a symlink) that no symlink is created