### PR TITLE
feat: add --relaxed flag for permissive filesystem with mandatory deny

### DIFF
--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -51,6 +51,7 @@ var (
 	secretVars             []string
 	ignoreVars             []string
 	skipVersionCheck       bool
+	relaxed                bool
 )
 
 func main() {
@@ -124,6 +125,7 @@ Configuration file format:
 	rootCmd.Flags().BoolVar(&learning, "learning", false, "Run in learning mode: trace filesystem access and generate a config profile")
 	rootCmd.Flags().StringVar(&profileName, "profile", "", "Load profiles by name, comma-separated (e.g. --profile claude,uv)")
 	rootCmd.Flags().BoolVar(&autoProfile, "auto-profile", false, "Use saved or built-in profile without prompting")
+	rootCmd.Flags().BoolVar(&relaxed, "relaxed", false, "Allow all filesystem reads and writes except mandatory deny lists (dangerous files, .env, git hooks)")
 	rootCmd.Flags().BoolVar(&noCredentialProtection, "no-credential-protection", false, "Disable credential substitution (real credentials visible in sandbox)")
 	rootCmd.Flags().StringArrayVar(&injectLabels, "inject", nil, "Inject a global credential by label (can be used multiple times, e.g. --inject ANTHROPIC_API_KEY)")
 	rootCmd.Flags().StringArrayVar(&secretVars, "secret", nil, "Protect an additional env var not in the default list (can be used multiple times)")
@@ -304,6 +306,12 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 	if dnsAddr != "" {
 		cfg.Network.DnsAddr = dnsAddr
+	}
+
+	// --relaxed flag overrides config
+	if relaxed {
+		t := true
+		cfg.Filesystem.Relaxed = &t
 	}
 
 	// GreyProxy defaults: when no proxy or DNS is configured (neither via CLI

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type NetworkConfig struct {
 // FilesystemConfig defines filesystem restrictions.
 type FilesystemConfig struct {
 	DefaultDenyRead *bool    `json:"defaultDenyRead,omitempty"` // If nil or true, deny reads by default except system paths, CWD, and AllowRead
+	Relaxed         *bool    `json:"relaxed,omitempty"`         // If true, allow all reads and writes except mandatory deny lists
 	AllowRead       []string `json:"allowRead"`                 // Paths to allow reading (used when DefaultDenyRead is true)
 	DenyRead        []string `json:"denyRead"`
 	AllowWrite      []string `json:"allowWrite"`
@@ -58,6 +59,13 @@ type FilesystemConfig struct {
 // Defaults to true when not explicitly set (nil).
 func (f *FilesystemConfig) IsDefaultDenyRead() bool {
 	return f.DefaultDenyRead == nil || *f.DefaultDenyRead
+}
+
+// IsRelaxed returns whether relaxed filesystem mode is enabled.
+// In relaxed mode, all reads and writes are allowed except mandatory deny lists
+// (dangerous files, sensitive project files, greyproxy keys, git hooks).
+func (f *FilesystemConfig) IsRelaxed() bool {
+	return f.Relaxed != nil && *f.Relaxed
 }
 
 // CommandConfig defines command restrictions.
@@ -460,8 +468,9 @@ func Merge(base, override *Config) *Config {
 		},
 
 		Filesystem: FilesystemConfig{
-			// Pointer field: override wins if set, otherwise base (nil = deny-by-default)
+			// Pointer fields: override wins if set, otherwise base
 			DefaultDenyRead: mergeOptionalBool(base.Filesystem.DefaultDenyRead, override.Filesystem.DefaultDenyRead),
+			Relaxed:         mergeOptionalBool(base.Filesystem.Relaxed, override.Filesystem.Relaxed),
 
 			// Append slices
 			AllowRead:  mergeStrings(base.Filesystem.AllowRead, override.Filesystem.AllowRead),

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -1044,10 +1044,19 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	}
 
 	defaultDenyRead := cfg != nil && cfg.Filesystem.IsDefaultDenyRead()
+	relaxedMode := cfg != nil && cfg.Filesystem.IsRelaxed()
 
 	switch {
 	case opts.Learning:
 		// Skip defaultDenyRead logic in learning mode (already set up above)
+	case relaxedMode:
+		// Relaxed mode: bind entire root filesystem read-write, mandatory deny lists still enforced
+		if opts.Debug {
+			fmt.Fprintf(os.Stderr, "[greywall:linux] Relaxed mode enabled - read-write root with mandatory deny overlays\n")
+		}
+		bwrapArgs = append(bwrapArgs, "--bind", "/", "/")
+		// Block D-Bus session bus to prevent sandbox escape via GVFS/gnome-keyring
+		bwrapArgs = append(bwrapArgs, dbusIsolationArgs(dbusBridge, opts.Debug)...)
 	case defaultDenyRead:
 		// Deny-by-default mode: start with empty root, then whitelist system paths + CWD
 		if opts.Debug {
@@ -1081,8 +1090,9 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	// /mnt/wsl/resolv.conf). After --ro-bind / / (non-recursive), separate
 	// mounts like /run are empty, so the symlink target is unreachable and
 	// bwrap fails with "Can't create file at /etc/resolv.conf".
-	if !defaultDenyRead {
+	if !defaultDenyRead || relaxedMode {
 		// In defaultDenyRead mode, resolv.conf symlink resolution is handled by runIsolationArgs.
+		// In relaxed mode, we use --bind / / (like legacy), so symlink resolution is needed.
 		if extra := resolveSymlinkForBind("/etc/resolv.conf", opts.Debug); len(extra) > 0 {
 			bwrapArgs = append(bwrapArgs, extra...)
 		}
@@ -1092,37 +1102,41 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	// (the sandbox is already permissive with home + cwd writable)
 	if !opts.Learning {
 
-		writablePaths := make(map[string]bool)
+		// In relaxed mode, root is already writable so skip explicit writable paths.
+		// In other modes, we need to make specific paths writable.
+		if !relaxedMode {
+			writablePaths := make(map[string]bool)
 
-		// Add default write paths (system paths needed for operation)
-		for _, p := range GetDefaultWritePaths() {
-			// Skip /dev paths (handled by --dev) and /tmp paths (handled by --tmpfs)
-			if strings.HasPrefix(p, "/dev/") || strings.HasPrefix(p, "/tmp/") || strings.HasPrefix(p, "/private/tmp/") {
-				continue
-			}
-			writablePaths[p] = true
-		}
-
-		// Add user-specified allowWrite paths
-		if cfg != nil && cfg.Filesystem.AllowWrite != nil {
-			expandedPaths := ExpandGlobPatterns(cfg.Filesystem.AllowWrite)
-			for _, p := range expandedPaths {
+			// Add default write paths (system paths needed for operation)
+			for _, p := range GetDefaultWritePaths() {
+				// Skip /dev paths (handled by --dev) and /tmp paths (handled by --tmpfs)
+				if strings.HasPrefix(p, "/dev/") || strings.HasPrefix(p, "/tmp/") || strings.HasPrefix(p, "/private/tmp/") {
+					continue
+				}
 				writablePaths[p] = true
 			}
 
-			// Add non-glob paths
-			for _, p := range cfg.Filesystem.AllowWrite {
-				normalized := NormalizePath(p)
-				if !ContainsGlobChars(normalized) {
-					writablePaths[normalized] = true
+			// Add user-specified allowWrite paths
+			if cfg != nil && cfg.Filesystem.AllowWrite != nil {
+				expandedPaths := ExpandGlobPatterns(cfg.Filesystem.AllowWrite)
+				for _, p := range expandedPaths {
+					writablePaths[p] = true
+				}
+
+				// Add non-glob paths
+				for _, p := range cfg.Filesystem.AllowWrite {
+					normalized := NormalizePath(p)
+					if !ContainsGlobChars(normalized) {
+						writablePaths[normalized] = true
+					}
 				}
 			}
-		}
 
-		// Make writable paths actually writable (override read-only root)
-		for p := range writablePaths {
-			if fileExists(p) {
-				bwrapArgs = append(bwrapArgs, "--bind", p, p)
+			// Make writable paths actually writable (override read-only root)
+			for p := range writablePaths {
+				if fileExists(p) {
+					bwrapArgs = append(bwrapArgs, "--bind", p, p)
+				}
 			}
 		}
 
@@ -1175,9 +1189,38 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		// by buildDenyByDefaultMounts() (either masked with empty file or mounted
 		// with rewritten content). Skip them here to avoid overriding.
 		maskedPaths := make(map[string]bool)
-		if defaultDenyRead {
+		if defaultDenyRead && !relaxedMode {
 			for _, f := range SensitiveProjectFiles {
 				maskedPaths[filepath.Join(cwd, f)] = true
+			}
+		}
+
+		// In relaxed mode, sensitive project files (.env) need to be masked or
+		// rewritten just like in deny-by-default mode, since root is fully writable.
+		if relaxedMode && cwd != "" {
+			var emptyFile string
+			for _, f := range SensitiveProjectFiles {
+				p := filepath.Join(cwd, f)
+				if !fileExists(p) {
+					continue
+				}
+				maskedPaths[p] = true
+				if rewrittenPath, ok := opts.RewrittenEnvFiles[p]; ok {
+					bwrapArgs = append(bwrapArgs, "--ro-bind", rewrittenPath, p)
+					if opts.Debug {
+						fmt.Fprintf(os.Stderr, "[greywall:linux] Relaxed: mounting rewritten %s (credentials replaced with placeholders)\n", f)
+					}
+				} else {
+					if emptyFile == "" {
+						emptyFile = filepath.Join(os.TempDir(), "greywall", "empty")
+						_ = os.MkdirAll(filepath.Dir(emptyFile), 0o750)
+						_ = os.WriteFile(emptyFile, nil, 0o444) //nolint:gosec // intentionally world-readable empty file for bind-mount masking
+					}
+					bwrapArgs = append(bwrapArgs, "--ro-bind", emptyFile, p)
+					if opts.Debug {
+						fmt.Fprintf(os.Stderr, "[greywall:linux] Relaxed: masking sensitive file: %s\n", f)
+					}
+				}
 			}
 		}
 

--- a/internal/sandbox/linux_landlock.go
+++ b/internal/sandbox/linux_landlock.go
@@ -44,6 +44,25 @@ func ApplyLandlockFromConfig(cfg *config.Config, cwd string, socketPaths []strin
 		return nil // Graceful fallback
 	}
 
+	// In relaxed mode, allow read+write on the entire filesystem.
+	// Mandatory deny is enforced by bwrap mount overlays, not Landlock.
+	relaxedMode := cfg != nil && cfg.Filesystem.IsRelaxed()
+	if relaxedMode {
+		if err := ruleset.AllowReadWrite("/"); err != nil && debug {
+			fmt.Fprintf(os.Stderr, "[greywall:landlock] Warning: failed to add root read/write path: %v\n", err)
+		}
+		if err := ruleset.Apply(); err != nil {
+			if debug {
+				fmt.Fprintf(os.Stderr, "[greywall:landlock] Failed to apply: %v\n", err)
+			}
+			return nil
+		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "[greywall:landlock] Applied relaxed restrictions (ABI v%d)\n", features.LandlockABI)
+		}
+		return nil
+	}
+
 	// Essential system paths - allow read+execute
 	// Note: /dev is handled separately with read+write for /dev/null, /dev/zero, etc.
 	systemReadPaths := []string{

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -42,6 +42,7 @@ type MacOSSandboxParams struct {
 	AllowLocalBinding       bool
 	AllowLocalOutbound      bool
 	DefaultDenyRead         bool
+	Relaxed                 bool   // Allow all reads and writes except mandatory deny lists
 	Cwd                     string // Current working directory (for deny-by-default CWD allowlisting)
 	ReadAllowPaths          []string
 	ReadDenyPaths           []string
@@ -304,45 +305,50 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 
 // generateWriteRules generates filesystem write rules for the sandbox profile.
 // When cwd is non-empty, it is automatically included in the write allow paths.
-func generateWriteRules(cwd string, allowPaths, denyPaths []string, allowGitConfig bool, logTag string) []string {
+func generateWriteRules(cwd string, allowPaths, denyPaths []string, allowGitConfig bool, relaxed bool, logTag string) []string {
 	var rules []string
 
-	// Auto-allow CWD for writes (project directory should be writable)
-	if cwd != "" {
-		rules = append(rules,
-			"(allow file-write*",
-			fmt.Sprintf("  (subpath %s)", escapePath(cwd)),
-			fmt.Sprintf("  (with message %q))", logTag),
-		)
-	}
-
-	// Allow TMPDIR parent on macOS
-	for _, tmpdirParent := range getTmpdirParent() {
-		normalized := NormalizePath(tmpdirParent)
-		rules = append(rules,
-			"(allow file-write*",
-			fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
-			fmt.Sprintf("  (with message %q))", logTag),
-		)
-	}
-
-	// Generate allow rules
-	for _, pathPattern := range allowPaths {
-		normalized := NormalizePath(pathPattern)
-
-		if ContainsGlobChars(normalized) {
-			regex := GlobToRegex(normalized)
+	if relaxed {
+		// Relaxed mode: allow all writes, then deny mandatory patterns
+		rules = append(rules, "(allow file-write*)")
+	} else {
+		// Auto-allow CWD for writes (project directory should be writable)
+		if cwd != "" {
 			rules = append(rules,
 				"(allow file-write*",
-				fmt.Sprintf("  (regex %s)", escapePath(regex)),
+				fmt.Sprintf("  (subpath %s)", escapePath(cwd)),
 				fmt.Sprintf("  (with message %q))", logTag),
 			)
-		} else {
+		}
+
+		// Allow TMPDIR parent on macOS
+		for _, tmpdirParent := range getTmpdirParent() {
+			normalized := NormalizePath(tmpdirParent)
 			rules = append(rules,
 				"(allow file-write*",
 				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 				fmt.Sprintf("  (with message %q))", logTag),
 			)
+		}
+
+		// Generate allow rules
+		for _, pathPattern := range allowPaths {
+			normalized := NormalizePath(pathPattern)
+
+			if ContainsGlobChars(normalized) {
+				regex := GlobToRegex(normalized)
+				rules = append(rules,
+					"(allow file-write*",
+					fmt.Sprintf("  (regex %s)", escapePath(regex)),
+					fmt.Sprintf("  (with message %q))", logTag),
+				)
+			} else {
+				rules = append(rules,
+					"(allow file-write*",
+					fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
+					fmt.Sprintf("  (with message %q))", logTag),
+				)
+			}
 		}
 	}
 
@@ -644,14 +650,16 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 
 	// Read rules
 	profile.WriteString("; File read\n")
-	for _, rule := range generateReadRules(params.DefaultDenyRead, params.Cwd, params.ReadAllowPaths, params.ReadDenyPaths, params.RewrittenEnvFiles, logTag) {
+	// In relaxed mode, allow all reads (same as defaultDenyRead=false)
+	effectiveDenyRead := params.DefaultDenyRead && !params.Relaxed
+	for _, rule := range generateReadRules(effectiveDenyRead, params.Cwd, params.ReadAllowPaths, params.ReadDenyPaths, params.RewrittenEnvFiles, logTag) {
 		profile.WriteString(rule + "\n")
 	}
 	profile.WriteString("\n")
 
 	// Write rules
 	profile.WriteString("; File write\n")
-	for _, rule := range generateWriteRules(params.Cwd, params.WriteAllowPaths, params.WriteDenyPaths, params.AllowGitConfig, logTag) {
+	for _, rule := range generateWriteRules(params.Cwd, params.WriteAllowPaths, params.WriteDenyPaths, params.AllowGitConfig, params.Relaxed, logTag) {
 		profile.WriteString(rule + "\n")
 	}
 
@@ -731,6 +739,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, exposedPorts []int, re
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		DefaultDenyRead:         cfg.Filesystem.IsDefaultDenyRead(),
+		Relaxed:                 cfg.Filesystem.IsRelaxed(),
 		Cwd:                     cwd,
 		ReadAllowPaths:          cfg.Filesystem.AllowRead,
 		ReadDenyPaths:           cfg.Filesystem.DenyRead,


### PR DESCRIPTION
## Summary

- Add `--relaxed` CLI flag and `filesystem.relaxed` config option
- When enabled, the entire filesystem is readable and writable inside the sandbox
- Mandatory deny lists are still enforced: dangerous files (`.bashrc`, `.gitconfig`, `.mcp.json`, etc.), sensitive project files (`.env*`), greyproxy keys, and git hooks
- Works on both Linux (bubblewrap `--bind / /` with `--ro-bind` overlays) and macOS (Seatbelt `(allow file-read*)` + `(allow file-write*)` with deny rules)
- Landlock early-returns with full root r/w access in relaxed mode

## Use case

For trusted commands that need broad filesystem access (e.g., build tools, IDEs) but should still be protected from accidentally modifying shell configs or leaking `.env` credentials.

```bash
greywall --relaxed -- make build
```

Or in config:
```json
{
  "filesystem": {
    "relaxed": true
  }
}
```

## Test plan

- [ ] `greywall --relaxed -- ls /root` confirms read access outside CWD
- [ ] `greywall --relaxed -- touch /tmp/test-relaxed` confirms write access
- [ ] `greywall --relaxed -- cat .env` confirms .env is still masked
- [ ] `greywall --relaxed -- cat ~/.bashrc && echo "test" >> ~/.bashrc` confirms .bashrc is read-only
- [ ] `greywall --relaxed -- cat ~/.gitconfig` confirms .gitconfig is read-only
- [ ] Verify on macOS: `greywall --relaxed -- touch ~/test-file` works
- [ ] `make test` passes