### PR TITLE
fix: add macOS stub, docs, and Merge() for allowAudio (#72)

### DIFF
--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -102,7 +102,8 @@ Configuration file format:
   },
   "command": {
     "deny": ["git push", "npm publish"]
-  }
+  },
+  "allowAudio": true
 }`,
 		RunE:          runCommand,
 		SilenceUsage:  true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,6 +249,7 @@ SSH host patterns support wildcards anywhere:
 | Field | Description |
 |-------|-------------|
 | `allowPty` | Allow pseudo-terminal (PTY) allocation in the sandbox (for MacOS) |
+| `allowAudio` | Expose PulseAudio and PipeWire sockets inside the sandbox so commands can produce audio output (Linux only). Note: these sockets also allow microphone capture and, via PipeWire, camera/screen access. Disabled by default. |
 
 ## Importing from Claude Code
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -439,6 +439,8 @@ func Merge(base, override *Config) *Config {
 	result := &Config{
 		// AllowPty: true if either config enables it
 		AllowPty: base.AllowPty || override.AllowPty,
+		// AllowAudio: true if either config enables it
+		AllowAudio: base.AllowAudio || override.AllowAudio,
 
 		Network: NetworkConfig{
 			// ProxyURL/HTTPProxyURL/DnsAddr: override wins if non-empty

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -64,6 +64,7 @@ type LinuxSandboxOptions struct {
 	Learning          bool
 	StraceLogPath     string
 	RewrittenEnvFiles map[string]string
+	AllowAudio        bool
 }
 
 // NewProxyBridge returns an error on non-Linux platforms.


### PR DESCRIPTION
## Summary

Follow-up fixes for #72 (expose PulseAudio and PipeWire sockets in sandbox):

- **macOS build fix**: Add missing `AllowAudio` field to `LinuxSandboxOptions` stub in `linux_stub.go`, which caused `[build failed]` on macOS CI
- **Documentation**: Add `allowAudio` to the "Other Options" table in `docs/configuration.md` and to the CLI help config example
- **Bug fix**: Propagate `AllowAudio` in `config.Merge()` (was missing, unlike `AllowPty`)

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] Verified `allowAudio: true` exposes PulseAudio/PipeWire sockets inside sandbox
- [x] Verified sockets are hidden without `allowAudio`