### PR TITLE
ci: notify docs repo on release

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,20 @@
+name: Notify docs repo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_SYNC_TOKEN }}
+          repository: GreyhavenHQ/docs
+          event-type: sync-docs
+          client-payload: |
+            {
+              "product": "greywall",
+              "ref": "${{ github.event.release.tag_name }}"
+            }


### PR DESCRIPTION
## Summary
- Adds a workflow that fires on `release: published` and sends a `repository_dispatch` to `GreyhavenHQ/docs` with the release tag.
- The docs repo has a matching sync workflow that checks out this repo at that tag and mirrors `docs/` into `docs/greywall/`.

Requires the `DOCS_SYNC_TOKEN` org secret (fine-grained PAT with `contents: write` on `GreyhavenHQ/docs`) to be granted to this repo.

## Test plan
- [x] Confirm `DOCS_SYNC_TOKEN` org secret is granted to this repo
- [ ] Cut a test pre-release and verify the "Notify docs repo" workflow runs green
- [ ] Verify the "Sync product docs" workflow fires in `GreyhavenHQ/docs` and commits an update