### PR TITLE
feat(prompt): show profile network rules in first-run prompt

### DIFF
--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -191,6 +191,12 @@ func TestPromptFirstRun(t *testing.T) {
 	if !strings.Contains(output, "Deny read:") {
 		t.Error("prompt output should show Deny read paths")
 	}
+	if !strings.Contains(output, "Allow net:") {
+		t.Error("prompt output should show Allow net rules for profiles with network rules")
+	}
+	if !strings.Contains(output, "api.anthropic.com") {
+		t.Error("prompt output should list the profile's network destinations")
+	}
 	if !strings.Contains(output, "[e]") {
 		t.Error("prompt output should show edit option")
 	}

--- a/internal/profiles/prompt.go
+++ b/internal/profiles/prompt.go
@@ -100,6 +100,31 @@ func hasWorkingDir(paths []string) bool {
 	return false
 }
 
+// formatNetworkRule renders a single network rule as "destination" or
+// "destination:port" when a non-wildcard port is set.
+func formatNetworkRule(r config.NetworkRule) string {
+	if r.Port == "" || r.Port == "*" {
+		return r.Destination
+	}
+	return r.Destination + ":" + r.Port
+}
+
+// formatNetworkRules returns a display string for the rules whose action matches.
+func formatNetworkRules(rules []config.NetworkRule, action string) string {
+	display := make([]string, 0, len(rules))
+	for _, r := range rules {
+		a := r.Action
+		if a == "" {
+			a = "allow"
+		}
+		if a != action {
+			continue
+		}
+		display = append(display, formatNetworkRule(r))
+	}
+	return strings.Join(display, "  ")
+}
+
 // PromptFirstRun shows the profile summary and asks the user how to proceed.
 func PromptFirstRun(agentName string, profile *config.Config, w io.Writer, r io.Reader) PromptResponse {
 	c := newColorizer(w)
@@ -130,6 +155,14 @@ func PromptFirstRun(agentName string, profile *config.Config, w io.Writer, r io.
 	}
 	if len(profile.Filesystem.DenyWrite) > 0 {
 		fmt.Fprintf(w, "%s  %s\n", c.red("Deny write:"), formatPaths(profile.Filesystem.DenyWrite)) //nolint:errcheck,gosec
+	}
+
+	// Network rules are forwarded to greyproxy as session-scoped rules.
+	if allowNet := formatNetworkRules(profile.Network.Rules, "allow"); allowNet != "" {
+		fmt.Fprintf(w, "%s  %s\n", c.green("Allow net: "), allowNet) //nolint:errcheck,gosec
+	}
+	if denyNet := formatNetworkRules(profile.Network.Rules, "deny"); denyNet != "" {
+		fmt.Fprintf(w, "%s   %s\n", c.red("Deny net:"), denyNet) //nolint:errcheck,gosec
 	}
 
 	fmt.Fprintln(w) //nolint:errcheck


### PR DESCRIPTION
## Summary
- The first-run profile prompt showed filesystem allow/deny lines but silently omitted the profile's network rules, so users approving \`greywall -- claude\` could not see which hosts were about to be pushed to greyproxy as session-scoped rules.
- Render \`Allow net:\` / \`Deny net:\` lines alongside the filesystem ones, reusing the same green/red coloring. Port is shown only when non-wildcard so the common \`host:443\` case stays compact.

## Before
\`\`\`
Allow read:   ~/CLAUDE.md  ...
Allow write: ~/.skills  ...
Deny read:   ~/.ssh/id_*  ...
Deny write:  ~/.bashrc  ...

[Y] Use profile (recommended) ...
\`\`\`

## After
\`\`\`
Allow read:   ~/CLAUDE.md  ...
Allow write: ~/.skills  ...
Deny read:   ~/.ssh/id_*  ...
Deny write:  ~/.bashrc  ...
Allow net:   api.anthropic.com:443  mcp-proxy.anthropic.com:443  downloads.claude.ai:443  platform.claude.com:443  github.com:443  api.github.com:443  *.githubusercontent.com:443  registry.npmjs.org:443  storage.googleapis.com:443

[Y] Use profile (recommended) ...
\`\`\`

## Test plan
- [x] \`go test ./internal/profiles/...\` passes with the extended assertions
- [x] Manual render of the claude profile prompt via a throwaway demo binary
- [x] Manual: run \`greywall -- claude\` interactively and verify the Allow net line appears