### PR TITLE
feat(cli): --proxy-user to inject a caller-chosen SOCKS5 username

### DIFF
--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -36,6 +36,7 @@ var (
 	settingsPath           string
 	proxyURL               string
 	httpProxyURL           string
+	proxyUserFlag          string
 	dnsAddr                string
 	cmdString              string
 	exposePorts            []string
@@ -120,6 +121,7 @@ Configuration file format:
 	rootCmd.Flags().StringVar(&proxyURL, "proxy", "", "External SOCKS5 proxy URL (default: socks5://localhost:43052)")
 	rootCmd.Flags().StringVar(&dnsAddr, "dns", "", "DNS server address on host (default: localhost:43053)")
 	rootCmd.Flags().StringVar(&httpProxyURL, "http-proxy", "", "HTTP CONNECT proxy URL (default: http://localhost:43051)")
+	rootCmd.Flags().StringVar(&proxyUserFlag, "proxy-user", "", "SOCKS5/HTTP proxy username to inject into the configured proxy URL (overrides any existing userinfo and the default auto-detected command name). Lets the upstream proxy match per-client rules by login.")
 	rootCmd.Flags().StringVarP(&cmdString, "c", "c", "", "Run command string directly (like sh -c)")
 	rootCmd.Flags().StringArrayVarP(&exposePorts, "port", "p", nil, "Expose port for inbound connections (can be used multiple times)")
 	rootCmd.Flags().StringArrayVarP(&forwardPorts, "forward", "f", nil, "Forward host localhost port into sandbox (can be used multiple times)")
@@ -340,11 +342,17 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Auto-inject proxy credentials so the proxy can identify the sandboxed command.
-	// - If a command name is available, use it as the username with "proxy" as password.
-	// - If no command name, default to "proxy:proxy" (required by gost for auth).
+	// Precedence (highest wins):
+	//   1. --proxy-user <name>   (explicit caller override, e.g. for per-agent
+	//                             identity in a multi-tenant setup)
+	//   2. cmdName               (auto-detected from the wrapped command)
+	//   3. "proxy"               (fallback, required by gost for auth)
 	// This always overrides any existing credentials in the URL.
 	proxyUser := "proxy"
-	if cmdName != "" {
+	switch {
+	case proxyUserFlag != "":
+		proxyUser = proxyUserFlag
+	case cmdName != "":
 		proxyUser = cmdName
 	}
 	for _, proxyField := range []*string{&cfg.Network.ProxyURL, &cfg.Network.HTTPProxyURL} {
@@ -356,7 +364,14 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if debug {
-		fmt.Fprintf(os.Stderr, "[greywall] Auto-set proxy credentials to %q:proxy\n", proxyUser)
+		source := "default"
+		switch {
+		case proxyUserFlag != "":
+			source = "--proxy-user"
+		case cmdName != "":
+			source = "command name"
+		}
+		fmt.Fprintf(os.Stderr, "[greywall] Auto-set proxy credentials to %q:proxy (source: %s)\n", proxyUser, source)
 	}
 
 	// Merge CLI forward ports into config


### PR DESCRIPTION
## Motivation

Today greywall auto-assigns the outbound proxy username based on the wrapped command name (`cmdName:proxy`), falling back to `proxy:proxy`. That works well for single-tenant use.

It does not work for orchestrators that run several independent sandboxed agents in parallel on the same machine and want per-agent rules on the upstream proxy (greyproxy). Both agents end up looking identical to the proxy, so a policy like *"agent-alpha may reach `api.openai.com`, agent-beta may not"* is impossible to express.

## Change

Adds a `--proxy-user <name>` flag on the root command. When set, `<name>` is used as the SOCKS5/HTTP proxy username for both `cfg.Network.ProxyURL` and `cfg.Network.HTTPProxyURL`, overriding the auto-detected command name.

Precedence (highest wins):

1. `--proxy-user <name>` — explicit caller override
2. `cmdName` — auto-detected from the wrapped command (existing behaviour)
3. `"proxy"` — fallback (gost requires a non-empty user)

The URL rewrite is done once in `runCommand` before any downstream consumer (proxy bridge, tun2socks, landlock wrapper config) reads the config, so the identity flows through every code path uniformly with no additional plumbing.

Debug logs now also name the source of the chosen username (`--proxy-user` / `command name` / `default`) to make it obvious where the identity came from.

## Backwards compatibility

No behavioural change when the flag is unset — the existing \`cmdName\`-based auto-injection still runs.

## Testing

Manual smoke test on Linux + macOS:

\`\`\`
\$ greywall --help | grep proxy-user
--proxy-user string  SOCKS5/HTTP proxy username to inject into the configured proxy URL ...

\$ greywall --debug --proxy-user myagent -- echo hello
[greywall] Auto-set proxy credentials to "myagent":proxy (source: --proxy-user)

\$ greywall --debug -- echo hello
[greywall] Auto-set proxy credentials to "echo":proxy (source: command name)
\`\`\`

Build: \`go build ./...\` on both \`darwin/arm64\` and \`linux/arm64\` — clean.

## Test plan

- [x] \`go build ./...\` on darwin/arm64
- [x] \`GOOS=linux GOARCH=arm64 go build ./...\`
- [x] Verify \`--help\` shows the new flag
- [x] Verify debug log output with \`--proxy-user myagent\`
- [x] Verify default (no-flag) path still uses \`cmdName\`