### PR TITLE
feat: nested-Docker sandbox — --no-bwrap, greywall-netns-helper, --netns, --bridge-port

### DIFF
--- a/cmd/greywall-netns-helper/main.go
+++ b/cmd/greywall-netns-helper/main.go
@@ -7,12 +7,15 @@
 //
 //	setcap cap_net_admin,cap_sys_admin+ep /usr/local/bin/greywall-netns-helper
 //
-// This binary has three subcommands:
+// This binary has three user-facing subcommands:
 //
-//	create  --proxy URL [--tun2socks PATH]
+//	create  --proxy URL [--tun2socks PATH] [--bridge-port N]
 //	    Creates a new netns, sets up tun0 + default route via tun2socks,
-//	    pins the netns at /run/greywall/ns-<uuid>, writes the tun2socks PID
-//	    at <pin>.pid, prints the pin path and exits.
+//	    pins the netns at /run/greywall/ns-<uuid>, and (if --bridge-port is
+//	    given) sets up a bidirectional TCP bridge so a host-netns client
+//	    can reach a TCP listener inside the pinned netns. Prints the pin
+//	    path and exits. Records all background PIDs in <pin>.pid (one per
+//	    line) for later cleanup by `destroy`.
 //
 //	exec    --netns PATH -- COMMAND [ARGS...]
 //	    Enters the pinned netns, drops ALL capabilities, then exec's
@@ -20,12 +23,17 @@
 //	    inside the netns without handing the caller any privilege.
 //
 //	destroy PATH
-//	    Kills the tun2socks process, unmounts the netns pin, removes the
-//	    pin file + sidecar .pid file.
+//	    SIGTERMs every recorded pid, unmounts the netns pin, removes the
+//	    pin, pid file, and bridge socket.
 //
-// It does not act as a general-purpose nsenter / shell wrapper: the `exec`
-// subcommand strictly refuses netns paths outside /run/greywall and drops
-// all caps before exec'ing the user command.
+// Plus one internal subcommand used only by `create` to spawn its host-netns
+// bridge sibling (you should never invoke it directly):
+//
+//	_bridge-host --socket PATH --port N
+//
+// The `exec` subcommand strictly refuses netns paths outside /run/greywall
+// and drops all caps (incl. ambient + bounding set) before exec'ing the
+// user command.
 package main
 
 import (
@@ -41,6 +49,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -62,6 +71,8 @@ func main() {
 		cmdExec(os.Args[2:])
 	case "destroy":
 		cmdDestroy(os.Args[2:])
+	case "_bridge-host":
+		cmdBridgeHost(os.Args[2:])
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -73,7 +84,7 @@ func main() {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "Usage:")
-	fmt.Fprintln(os.Stderr, "  greywall-netns-helper create --proxy socks5://host:port [--tun2socks /path/to/tun2socks]")
+	fmt.Fprintln(os.Stderr, "  greywall-netns-helper create --proxy socks5://host:port [--tun2socks PATH] [--bridge-port N]")
 	fmt.Fprintln(os.Stderr, "  greywall-netns-helper exec --netns /run/greywall/ns-<id> -- <command> [args...]")
 	fmt.Fprintln(os.Stderr, "  greywall-netns-helper destroy /run/greywall/ns-<id>")
 }
@@ -86,6 +97,7 @@ func cmdCreate(args []string) {
 	fs := flag.NewFlagSet("create", flag.ExitOnError)
 	proxy := fs.String("proxy", "", "SOCKS5 proxy URL, e.g. socks5://host:port (required)")
 	tun2socksBin := fs.String("tun2socks", "/usr/local/bin/tun2socks", "Path to tun2socks binary")
+	bridgePort := fs.Int("bridge-port", 0, "If set, bridge host-netns TCP port N <-> inside-netns TCP 127.0.0.1:N via a Unix socket")
 	debug := fs.Bool("debug", false, "Verbose stderr logging")
 	_ = fs.Parse(args)
 
@@ -95,12 +107,74 @@ func cmdCreate(args []string) {
 	if _, err := os.Stat(*tun2socksBin); err != nil {
 		die("create: tun2socks binary not found at %s: %v", *tun2socksBin, err)
 	}
+	if _, err := exec.LookPath("socat"); err != nil && *bridgePort != 0 {
+		die("create: --bridge-port requires socat in PATH")
+	}
+	selfExe, err := os.Executable()
+	if err != nil {
+		die("create: cannot resolve own executable path: %v", err)
+	}
 
+	// Generate the pin path up-front so we can pass its .sock sibling to
+	// the host-netns bridge launcher before we unshare.
+	if err := os.MkdirAll(pinDir, 0o755); err != nil {
+		die("create: mkdir %s: %v", pinDir, err)
+	}
+	id := make([]byte, 8)
+	if _, err := rand.Read(id); err != nil {
+		die("create: rand: %v", err)
+	}
+	pinPath := filepath.Join(pinDir, fmt.Sprintf("ns-%s", hex.EncodeToString(id)))
+	socketPath := pinPath + ".sock"
+
+	var pids []int // collect for the sidecar pidfile
+
+	// --- 1. Host-netns bridge sibling --------------------------------------
+	//
+	// Spawn this BEFORE unshare(CLONE_NEWNET) so it stays in the host netns.
+	// It polls until the Unix socket appears, then execs socat to accept TCP
+	// on 127.0.0.1:<bridge-port> and forward to the Unix socket. We never
+	// put the user-supplied port directly on the command line to socat
+	// without --bind=127.0.0.1, so nothing else on the host can connect.
+	if *bridgePort != 0 {
+		args := []string{
+			selfExe, "_bridge-host",
+			"--socket", socketPath,
+			"--port", strconv.Itoa(*bridgePort),
+		}
+		if *debug {
+			args = append(args, "--debug")
+		}
+		//nolint:gosec // selfExe + subcommand are trusted
+		bridge := exec.Command(args[0], args[1:]...)
+		devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		if err != nil {
+			die("create: open /dev/null: %v", err)
+		}
+		bridge.Stdin = devnull
+		bridge.Stdout = devnull
+		bridge.Stderr = devnull
+		bridge.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		if err := bridge.Start(); err != nil {
+			_ = devnull.Close()
+			die("create: spawn host-netns bridge: %v", err)
+		}
+		_ = devnull.Close()
+		pids = append(pids, bridge.Process.Pid)
+		if *debug {
+			fmt.Fprintf(os.Stderr, "[netns-helper] host-bridge pid=%d (TCP 127.0.0.1:%d <- unix://%s)\n",
+				bridge.Process.Pid, *bridgePort, socketPath)
+		}
+	}
+
+	// --- 2. Enter a fresh netns --------------------------------------------
+	//
 	// Lock OS thread so the netns unshare only affects this thread. We
 	// exec tun2socks (as a child) and exit, so the lock is temporary.
 	runtime.LockOSThread()
 
 	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
+		_ = killPids(pids) // kill the orphaned host-netns bridge sibling
 		die("create: unshare(CLONE_NEWNET) failed: %v (need CAP_SYS_ADMIN)", err)
 	}
 
@@ -109,6 +183,7 @@ func cmdCreate(args []string) {
 	// ambient set. `ip` and `tun2socks` are separate binaries that need
 	// CAP_NET_ADMIN to manipulate interfaces.
 	if err := raiseAmbient(capNetAdmin); err != nil {
+		_ = killPids(pids)
 		die("create: raise ambient CAP_NET_ADMIN: %v", err)
 	}
 
@@ -123,6 +198,7 @@ func cmdCreate(args []string) {
 	for _, c := range setupCmds {
 		cmd := exec.Command(c[0], c[1:]...) //nolint:gosec // args are fixed strings
 		if out, err := cmd.CombinedOutput(); err != nil {
+			_ = killPids(pids)
 			die("create: %s failed: %v\n  %s", strings.Join(c, " "), err, strings.TrimSpace(string(out)))
 		}
 		if *debug {
@@ -130,58 +206,86 @@ func cmdCreate(args []string) {
 		}
 	}
 
-	// Pin the netns at /run/greywall/ns-<uuid>
-	if err := os.MkdirAll(pinDir, 0o755); err != nil {
-		die("create: mkdir %s: %v", pinDir, err)
-	}
-	id := make([]byte, 8)
-	if _, err := rand.Read(id); err != nil {
-		die("create: rand: %v", err)
-	}
-	pinPath := filepath.Join(pinDir, fmt.Sprintf("ns-%s", hex.EncodeToString(id)))
+	// --- 3. Pin the netns at /run/greywall/ns-<uuid> -----------------------
 
 	// Pre-create the mount target as an empty regular file.
 	f, err := os.OpenFile(pinPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
+		_ = killPids(pids)
 		die("create: pin file %s: %v", pinPath, err)
 	}
 	_ = f.Close()
 
 	if err := unix.Mount("/proc/self/ns/net", pinPath, "", unix.MS_BIND, ""); err != nil {
+		_ = killPids(pids)
 		_ = os.Remove(pinPath)
 		die("create: bind mount netns to %s: %v", pinPath, err)
 	}
 
-	// Launch tun2socks inside this netns. Because we unshared earlier, our
-	// children inherit the new netns.
+	// --- 4. tun2socks inside the netns -------------------------------------
+
 	devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {
-		cleanupPin(pinPath)
+		cleanupAll(pinPath, pids)
 		die("create: open /dev/null: %v", err)
 	}
+	defer func() { _ = devnull.Close() }()
 
-	cmd := exec.Command(*tun2socksBin, "-device", "tun0", "-proxy", *proxy) //nolint:gosec // proxy/tun2socks validated above
-	cmd.Stdin = devnull
-	cmd.Stdout = devnull
-	cmd.Stderr = devnull
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	if err := cmd.Start(); err != nil {
-		_ = devnull.Close()
-		cleanupPin(pinPath)
+	tun2socksCmd := exec.Command(*tun2socksBin, "-device", "tun0", "-proxy", *proxy) //nolint:gosec // proxy/tun2socks validated above
+	tun2socksCmd.Stdin = devnull
+	tun2socksCmd.Stdout = devnull
+	tun2socksCmd.Stderr = devnull
+	tun2socksCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := tun2socksCmd.Start(); err != nil {
+		cleanupAll(pinPath, pids)
 		die("create: tun2socks start: %v", err)
 	}
-	_ = devnull.Close()
+	pids = append(pids, tun2socksCmd.Process.Pid)
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[netns-helper] tun2socks pid=%d\n", tun2socksCmd.Process.Pid)
+	}
 
-	// Record the pid so destroy can stop it cleanly.
-	if err := os.WriteFile(pinPath+".pid", []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o644); err != nil {
+	// --- 5. Inside-netns bridge socat (only when --bridge-port given) ------
+	//
+	// socat UNIX-LISTEN:<socket>,fork,reuseaddr TCP:127.0.0.1:<port>
+	// listens on the shared-filesystem Unix socket and forwards each
+	// accepted connection to the TCP port where opencode will bind.
+	// Because we're inside the netns, the TCP endpoint is opencode's
+	// in-netns loopback.
+	if *bridgePort != 0 {
+		socatArgs := []string{
+			"socat",
+			fmt.Sprintf("UNIX-LISTEN:%s,fork,reuseaddr,mode=0660", socketPath),
+			fmt.Sprintf("TCP:127.0.0.1:%d", *bridgePort),
+		}
+		sc := exec.Command(socatArgs[0], socatArgs[1:]...) //nolint:gosec // args trusted
+		sc.Stdin = devnull
+		sc.Stdout = devnull
+		sc.Stderr = devnull
+		sc.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		if err := sc.Start(); err != nil {
+			cleanupAll(pinPath, pids)
+			die("create: inside-netns socat start: %v", err)
+		}
+		pids = append(pids, sc.Process.Pid)
+		if *debug {
+			fmt.Fprintf(os.Stderr, "[netns-helper] inside-socat pid=%d (unix://%s -> tcp://127.0.0.1:%d)\n",
+				sc.Process.Pid, socketPath, *bridgePort)
+		}
+	}
+
+	// --- 6. Record pids for `destroy` --------------------------------------
+
+	var sb strings.Builder
+	for _, p := range pids {
+		fmt.Fprintf(&sb, "%d\n", p)
+	}
+	if err := os.WriteFile(pinPath+".pid", []byte(sb.String()), 0o644); err != nil {
 		if *debug {
 			fmt.Fprintf(os.Stderr, "[netns-helper] warning: failed to write pidfile: %v\n", err)
 		}
 	}
 
-	if *debug {
-		fmt.Fprintf(os.Stderr, "[netns-helper] tun2socks pid=%d, pin=%s\n", cmd.Process.Pid, pinPath)
-	}
 	fmt.Println(pinPath)
 }
 
@@ -189,6 +293,78 @@ func cleanupPin(path string) {
 	_ = unix.Unmount(path, 0)
 	_ = os.Remove(path)
 	_ = os.Remove(path + ".pid")
+	_ = os.Remove(path + ".sock")
+}
+
+func cleanupAll(path string, pids []int) {
+	_ = killPids(pids)
+	cleanupPin(path)
+}
+
+func killPids(pids []int) error {
+	for _, p := range pids {
+		if p > 0 {
+			_ = syscall.Kill(p, syscall.SIGTERM)
+		}
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// _bridge-host (internal)
+// -----------------------------------------------------------------------------
+
+func cmdBridgeHost(args []string) {
+	fs := flag.NewFlagSet("_bridge-host", flag.ExitOnError)
+	socketPath := fs.String("socket", "", "Unix socket path to connect to (required)")
+	port := fs.Int("port", 0, "TCP port to listen on at 127.0.0.1 (required)")
+	debug := fs.Bool("debug", false, "Verbose stderr logging")
+	_ = fs.Parse(args)
+
+	if *socketPath == "" || *port == 0 {
+		die("_bridge-host: --socket and --port are required")
+	}
+	if err := validatePinPath(strings.TrimSuffix(*socketPath, ".sock")); err != nil {
+		// We only accept sockets that live alongside a valid pin path, so
+		// this binary's file caps can't be leveraged to proxy arbitrary
+		// Unix sockets.
+		die("_bridge-host: %v", err)
+	}
+
+	// Wait up to 10s for the Unix socket to appear — the inside-netns
+	// socat only starts it after the parent finishes unshare + tun setup.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(*socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			die("_bridge-host: timeout waiting for %s", *socketPath)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Drop all caps before handing control to socat; we don't need them
+	// (port > 1024 doesn't require CAP_NET_BIND_SERVICE) and the less
+	// privilege the better.
+	_ = dropAllCaps()
+	_ = clearBoundingSet()
+
+	socatPath, err := exec.LookPath("socat")
+	if err != nil {
+		die("_bridge-host: socat not in PATH: %v", err)
+	}
+	socatArgs := []string{
+		"socat",
+		fmt.Sprintf("TCP4-LISTEN:%d,bind=127.0.0.1,fork,reuseaddr", *port),
+		fmt.Sprintf("UNIX-CONNECT:%s", *socketPath),
+	}
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[netns-helper:_bridge-host] exec %s\n", strings.Join(socatArgs, " "))
+	}
+	if err := syscall.Exec(socatPath, socatArgs, os.Environ()); err != nil { //nolint:gosec
+		die("_bridge-host: exec socat: %v", err)
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -272,10 +448,10 @@ func validatePinPath(path string) error {
 		return fmt.Errorf("invalid path %q: %w", path, err)
 	}
 	if !strings.HasPrefix(clean, pinDir+"/") {
-		return fmt.Errorf("netns path must be under %s (got %s)", pinDir, clean)
+		return fmt.Errorf("path must be under %s (got %s)", pinDir, clean)
 	}
 	if strings.Contains(clean, "/..") {
-		return errors.New("netns path must not contain ..")
+		return errors.New("path must not contain ..")
 	}
 	return nil
 }
@@ -293,10 +469,16 @@ func cmdDestroy(args []string) {
 		die("destroy: %v", err)
 	}
 
-	// Stop tun2socks if we know its pid.
+	// Read all recorded pids; kill each with SIGTERM.
 	if data, err := os.ReadFile(path + ".pid"); err == nil {
-		if pid, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil && pid > 0 {
-			_ = syscall.Kill(pid, syscall.SIGTERM)
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if pid, perr := strconv.Atoi(line); perr == nil && pid > 0 {
+				_ = syscall.Kill(pid, syscall.SIGTERM)
+			}
 		}
 	}
 

--- a/cmd/greywall-netns-helper/main.go
+++ b/cmd/greywall-netns-helper/main.go
@@ -1,0 +1,412 @@
+//go:build linux
+
+// greywall-netns-helper creates and enters a persistent network namespace
+// with a tun2socks bridge to an external SOCKS5 proxy. It is intended to be
+// installed with file capabilities so it (and only it) can create and enter
+// netns as an unprivileged user:
+//
+//	setcap cap_net_admin,cap_sys_admin+ep /usr/local/bin/greywall-netns-helper
+//
+// This binary has three subcommands:
+//
+//	create  --proxy URL [--tun2socks PATH]
+//	    Creates a new netns, sets up tun0 + default route via tun2socks,
+//	    pins the netns at /run/greywall/ns-<uuid>, writes the tun2socks PID
+//	    at <pin>.pid, prints the pin path and exits.
+//
+//	exec    --netns PATH -- COMMAND [ARGS...]
+//	    Enters the pinned netns, drops ALL capabilities, then exec's
+//	    COMMAND. Used by greywall's --netns flag to run the wrapped command
+//	    inside the netns without handing the caller any privilege.
+//
+//	destroy PATH
+//	    Kills the tun2socks process, unmounts the netns pin, removes the
+//	    pin file + sidecar .pid file.
+//
+// It does not act as a general-purpose nsenter / shell wrapper: the `exec`
+// subcommand strictly refuses netns paths outside /run/greywall and drops
+// all caps before exec'ing the user command.
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	pinDir = "/run/greywall"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "create":
+		cmdCreate(os.Args[2:])
+	case "exec":
+		cmdExec(os.Args[2:])
+	case "destroy":
+		cmdDestroy(os.Args[2:])
+	case "-h", "--help", "help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "greywall-netns-helper: unknown subcommand %q\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "Usage:")
+	fmt.Fprintln(os.Stderr, "  greywall-netns-helper create --proxy socks5://host:port [--tun2socks /path/to/tun2socks]")
+	fmt.Fprintln(os.Stderr, "  greywall-netns-helper exec --netns /run/greywall/ns-<id> -- <command> [args...]")
+	fmt.Fprintln(os.Stderr, "  greywall-netns-helper destroy /run/greywall/ns-<id>")
+}
+
+// -----------------------------------------------------------------------------
+// create
+// -----------------------------------------------------------------------------
+
+func cmdCreate(args []string) {
+	fs := flag.NewFlagSet("create", flag.ExitOnError)
+	proxy := fs.String("proxy", "", "SOCKS5 proxy URL, e.g. socks5://host:port (required)")
+	tun2socksBin := fs.String("tun2socks", "/usr/local/bin/tun2socks", "Path to tun2socks binary")
+	debug := fs.Bool("debug", false, "Verbose stderr logging")
+	_ = fs.Parse(args)
+
+	if *proxy == "" {
+		die("create: --proxy is required")
+	}
+	if _, err := os.Stat(*tun2socksBin); err != nil {
+		die("create: tun2socks binary not found at %s: %v", *tun2socksBin, err)
+	}
+
+	// Lock OS thread so the netns unshare only affects this thread. We
+	// exec tun2socks (as a child) and exit, so the lock is temporary.
+	runtime.LockOSThread()
+
+	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
+		die("create: unshare(CLONE_NEWNET) failed: %v (need CAP_SYS_ADMIN)", err)
+	}
+
+	// File caps put CAP_NET_ADMIN/CAP_SYS_ADMIN in our permitted+effective,
+	// but children do NOT inherit those unless we raise them into the
+	// ambient set. `ip` and `tun2socks` are separate binaries that need
+	// CAP_NET_ADMIN to manipulate interfaces.
+	if err := raiseAmbient(capNetAdmin); err != nil {
+		die("create: raise ambient CAP_NET_ADMIN: %v", err)
+	}
+
+	// We're now in a fresh netns. lo is down; tun0 does not yet exist.
+	setupCmds := [][]string{
+		{"ip", "link", "set", "lo", "up"},
+		{"ip", "tuntap", "add", "dev", "tun0", "mode", "tun"},
+		{"ip", "addr", "add", "198.18.0.1/15", "dev", "tun0"},
+		{"ip", "link", "set", "tun0", "up"},
+		{"ip", "route", "add", "default", "via", "198.18.0.1", "dev", "tun0"},
+	}
+	for _, c := range setupCmds {
+		cmd := exec.Command(c[0], c[1:]...) //nolint:gosec // args are fixed strings
+		if out, err := cmd.CombinedOutput(); err != nil {
+			die("create: %s failed: %v\n  %s", strings.Join(c, " "), err, strings.TrimSpace(string(out)))
+		}
+		if *debug {
+			fmt.Fprintf(os.Stderr, "[netns-helper] %s ok\n", strings.Join(c, " "))
+		}
+	}
+
+	// Pin the netns at /run/greywall/ns-<uuid>
+	if err := os.MkdirAll(pinDir, 0o755); err != nil {
+		die("create: mkdir %s: %v", pinDir, err)
+	}
+	id := make([]byte, 8)
+	if _, err := rand.Read(id); err != nil {
+		die("create: rand: %v", err)
+	}
+	pinPath := filepath.Join(pinDir, fmt.Sprintf("ns-%s", hex.EncodeToString(id)))
+
+	// Pre-create the mount target as an empty regular file.
+	f, err := os.OpenFile(pinPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		die("create: pin file %s: %v", pinPath, err)
+	}
+	_ = f.Close()
+
+	if err := unix.Mount("/proc/self/ns/net", pinPath, "", unix.MS_BIND, ""); err != nil {
+		_ = os.Remove(pinPath)
+		die("create: bind mount netns to %s: %v", pinPath, err)
+	}
+
+	// Launch tun2socks inside this netns. Because we unshared earlier, our
+	// children inherit the new netns.
+	devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		cleanupPin(pinPath)
+		die("create: open /dev/null: %v", err)
+	}
+
+	cmd := exec.Command(*tun2socksBin, "-device", "tun0", "-proxy", *proxy) //nolint:gosec // proxy/tun2socks validated above
+	cmd.Stdin = devnull
+	cmd.Stdout = devnull
+	cmd.Stderr = devnull
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		_ = devnull.Close()
+		cleanupPin(pinPath)
+		die("create: tun2socks start: %v", err)
+	}
+	_ = devnull.Close()
+
+	// Record the pid so destroy can stop it cleanly.
+	if err := os.WriteFile(pinPath+".pid", []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o644); err != nil {
+		if *debug {
+			fmt.Fprintf(os.Stderr, "[netns-helper] warning: failed to write pidfile: %v\n", err)
+		}
+	}
+
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[netns-helper] tun2socks pid=%d, pin=%s\n", cmd.Process.Pid, pinPath)
+	}
+	fmt.Println(pinPath)
+}
+
+func cleanupPin(path string) {
+	_ = unix.Unmount(path, 0)
+	_ = os.Remove(path)
+	_ = os.Remove(path + ".pid")
+}
+
+// -----------------------------------------------------------------------------
+// exec
+// -----------------------------------------------------------------------------
+
+func cmdExec(args []string) {
+	// Parse: --netns PATH [--] <command> [args...]
+	var netnsPath string
+	var cmdStart int
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--netns":
+			if i+1 >= len(args) {
+				die("exec: --netns requires a value")
+			}
+			netnsPath = args[i+1]
+			i++
+		case "--":
+			cmdStart = i + 1
+			goto runit
+		default:
+			cmdStart = i
+			goto runit
+		}
+	}
+runit:
+	if netnsPath == "" {
+		die("exec: --netns is required")
+	}
+	if cmdStart >= len(args) {
+		die("exec: no command specified")
+	}
+	if err := validatePinPath(netnsPath); err != nil {
+		die("exec: %v", err)
+	}
+	command := args[cmdStart:]
+
+	// Open the netns fd first (while we still have CAP_SYS_ADMIN).
+	fd, err := unix.Open(netnsPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		die("exec: open %s: %v", netnsPath, err)
+	}
+
+	// Lock the thread, enter the netns, then drop caps. We will exec
+	// momentarily which replaces the whole process so the lock is safe.
+	runtime.LockOSThread()
+
+	if err := unix.Setns(fd, unix.CLONE_NEWNET); err != nil {
+		die("exec: setns: %v", err)
+	}
+	_ = unix.Close(fd)
+
+	if err := dropAllCaps(); err != nil {
+		die("exec: dropAllCaps: %v", err)
+	}
+	// Also clear the bounding set so exec'd program cannot gain caps from
+	// any file caps on the target binary.
+	if err := clearBoundingSet(); err != nil {
+		// Non-fatal: bounding-set clear can fail in some containers, but
+		// we've already cleared permitted+effective which is the primary
+		// defense.
+		fmt.Fprintf(os.Stderr, "[netns-helper] warning: clearBoundingSet: %v\n", err)
+	}
+
+	// Find the target and exec (replaces current process).
+	execPath, err := exec.LookPath(command[0])
+	if err != nil {
+		die("exec: command not found: %s", command[0])
+	}
+	if err := syscall.Exec(execPath, command, os.Environ()); err != nil { //nolint:gosec
+		die("exec: syscall.Exec: %v", err)
+	}
+}
+
+// validatePinPath rejects anything outside pinDir to prevent abuse of the
+// file caps for arbitrary netns entry.
+func validatePinPath(path string) error {
+	clean, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q: %w", path, err)
+	}
+	if !strings.HasPrefix(clean, pinDir+"/") {
+		return fmt.Errorf("netns path must be under %s (got %s)", pinDir, clean)
+	}
+	if strings.Contains(clean, "/..") {
+		return errors.New("netns path must not contain ..")
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// destroy
+// -----------------------------------------------------------------------------
+
+func cmdDestroy(args []string) {
+	if len(args) != 1 {
+		die("destroy: exactly one pin path required")
+	}
+	path := args[0]
+	if err := validatePinPath(path); err != nil {
+		die("destroy: %v", err)
+	}
+
+	// Stop tun2socks if we know its pid.
+	if data, err := os.ReadFile(path + ".pid"); err == nil {
+		if pid, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil && pid > 0 {
+			_ = syscall.Kill(pid, syscall.SIGTERM)
+		}
+	}
+
+	cleanupPin(path)
+}
+
+// -----------------------------------------------------------------------------
+// capability helpers
+// -----------------------------------------------------------------------------
+
+// capUserHeader matches Linux's cap_user_header_t.
+type capUserHeader struct {
+	version uint32
+	pid     int32
+}
+
+// capUserData matches Linux's cap_user_data_t for _LINUX_CAPABILITY_VERSION_3.
+type capUserData struct {
+	effective   uint32
+	permitted   uint32
+	inheritable uint32
+}
+
+// _LINUX_CAPABILITY_VERSION_3 (linux/capability.h)
+const linuxCapabilityVersion3 = 0x20080522
+
+// Capability numbers we use; matches include/uapi/linux/capability.h.
+const (
+	capNetAdmin = 12
+	capSysAdmin = 21
+)
+
+// prctlCapAmbientClearAll = PR_CAP_AMBIENT_CLEAR_ALL (prctl.h).
+const prctlCapAmbientClearAll = 4
+
+// raiseAmbient promotes a capability into the ambient set so that children
+// exec'd by this process inherit it. The cap must already be in both the
+// permitted and inheritable sets — we add it to inheritable first.
+func raiseAmbient(capNum int) error {
+	hdr := capUserHeader{version: linuxCapabilityVersion3, pid: 0}
+	var data [2]capUserData
+	if _, _, errno := unix.Syscall(
+		unix.SYS_CAPGET,
+		uintptr(unsafe.Pointer(&hdr)),  //nolint:gosec
+		uintptr(unsafe.Pointer(&data)), //nolint:gosec
+		0,
+	); errno != 0 {
+		return fmt.Errorf("capget: %w", errno)
+	}
+
+	idx := capNum / 32
+	bit := uint32(1) << (capNum % 32) //nolint:gosec // capNum fits in uint32
+	if data[idx].permitted&bit == 0 {
+		return fmt.Errorf("cap %d not in permitted set (file caps missing?)", capNum)
+	}
+	data[idx].inheritable |= bit
+
+	if _, _, errno := unix.Syscall(
+		unix.SYS_CAPSET,
+		uintptr(unsafe.Pointer(&hdr)),  //nolint:gosec
+		uintptr(unsafe.Pointer(&data)), //nolint:gosec
+		0,
+	); errno != 0 {
+		return fmt.Errorf("capset (add to inheritable): %w", errno)
+	}
+
+	if err := unix.Prctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_RAISE, uintptr(capNum), 0, 0); err != nil {
+		return fmt.Errorf("PR_CAP_AMBIENT_RAISE(%d): %w", capNum, err)
+	}
+	return nil
+}
+
+// dropAllCaps clears effective, permitted, inheritable AND the ambient
+// capability set for the calling thread. We call this just before
+// syscall.Exec so the exec'd program starts with empty caps and cannot
+// pick any up via ambient inheritance.
+func dropAllCaps() error {
+	// Clear ambient first (requires only caller privilege; no caps needed).
+	if err := unix.Prctl(unix.PR_CAP_AMBIENT, prctlCapAmbientClearAll, 0, 0, 0); err != nil {
+		return fmt.Errorf("PR_CAP_AMBIENT_CLEAR_ALL: %w", err)
+	}
+
+	hdr := capUserHeader{version: linuxCapabilityVersion3, pid: 0}
+	var data [2]capUserData // all zero
+	_, _, errno := unix.Syscall(
+		unix.SYS_CAPSET,
+		uintptr(unsafe.Pointer(&hdr)),  //nolint:gosec // syscall needs pointer
+		uintptr(unsafe.Pointer(&data)), //nolint:gosec // syscall needs pointer
+		0,
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// clearBoundingSet drops every capability from the thread's bounding set
+// via repeated PR_CAPBSET_DROP calls. Enumerates 0..64 which covers all
+// currently-defined caps.
+func clearBoundingSet() error {
+	for capNum := 0; capNum < 64; capNum++ {
+		// Ignore EINVAL for unknown cap numbers.
+		_ = unix.Prctl(unix.PR_CAPBSET_DROP, uintptr(capNum), 0, 0, 0)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+
+func die(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "greywall-netns-helper: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/greywall-netns-helper/stub.go
+++ b/cmd/greywall-netns-helper/stub.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+// Stub for non-Linux platforms: greywall-netns-helper is a Linux-only binary
+// that relies on CLONE_NEWNET + Landlock/seccomp on Linux. This file exists
+// so `go build ./...` on macOS (for developer convenience) still succeeds.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "greywall-netns-helper is only supported on Linux")
+	os.Exit(1)
+}

--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -54,6 +54,7 @@ var (
 	skipVersionCheck       bool
 	allowDests             []string
 	blankProfile           bool
+	noBwrap                bool
 )
 
 func main() {
@@ -126,6 +127,7 @@ Configuration file format:
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version information")
 	rootCmd.Flags().BoolVar(&linuxFeatures, "linux-features", false, "Show available Linux security features and exit")
 	rootCmd.Flags().BoolVar(&learning, "learning", false, "Run in learning mode: trace filesystem access and generate a config profile")
+	rootCmd.Flags().BoolVar(&noBwrap, "no-bwrap", false, "Skip bubblewrap; enforce via Landlock + seccomp only (for nested-Docker environments where bwrap cannot create user namespaces)")
 	rootCmd.Flags().StringVar(&profileName, "profile", "", "Load profiles by name, comma-separated (e.g. --profile claude,uv)")
 	rootCmd.Flags().BoolVar(&noNetworkRules, "no-network-rules", false, "Skip applying profile network rules to greyproxy (filesystem + keyring still apply)")
 	rootCmd.Flags().BoolVar(&autoProfile, "auto-profile", false, "Use saved or built-in profile without prompting")
@@ -378,6 +380,12 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	if learning {
 		manager.SetLearning(true)
 		manager.SetCommandName(cmdName)
+	}
+	if noBwrap {
+		manager.SetNoBwrap(true)
+		if debug {
+			fmt.Fprintf(os.Stderr, "[greywall] --no-bwrap mode: Landlock + seccomp only, no namespaces\n")
+		}
 	}
 	defer manager.Cleanup()
 
@@ -1255,20 +1263,30 @@ profiles, first save a copy with --learning or copy the output of "profiles show
 }
 
 // runLandlockWrapper runs in "wrapper mode" inside the sandbox.
-// It applies Landlock restrictions and then execs the user command.
-// Usage: greywall --landlock-apply [--debug] -- <command...>
+// It applies Landlock restrictions (and optionally seccomp) and then execs
+// the user command.
+//
+// Usage: greywall --landlock-apply [--debug] [--seccomp] -- <command...>
+//
 // Config is passed via GREYWALL_CONFIG_JSON environment variable.
+//
+// The --seccomp flag is used by --no-bwrap mode: without bwrap, we no longer
+// have a way to load the seccomp filter via --seccomp <fd>, so we load it
+// directly here, right after Landlock.
 func runLandlockWrapper() {
-	// Parse arguments: --landlock-apply [--debug] -- <command...>
+	// Parse arguments: --landlock-apply [--debug] [--seccomp] -- <command...>
 	args := os.Args[2:] // Skip "greywall" and "--landlock-apply"
 
 	var debugMode bool
+	var applySeccomp bool
 	var cmdStart int
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--debug":
 			debugMode = true
+		case "--seccomp":
+			applySeccomp = true
 		case "--":
 			cmdStart = i + 1
 			goto parseCommand
@@ -1320,6 +1338,15 @@ parseCommand:
 			// Continue without Landlock - bwrap still provides isolation
 		} else if debugMode {
 			fmt.Fprintf(os.Stderr, "[greywall:landlock-wrapper] Landlock restrictions applied\n")
+		}
+
+		// Apply seccomp after Landlock (both require NO_NEW_PRIVS; Landlock
+		// already set it, but ApplySeccompFilter re-asserts it idempotently).
+		if applySeccomp {
+			if err := sandbox.ApplySeccompFilter(debugMode); err != nil {
+				fmt.Fprintf(os.Stderr, "[greywall:landlock-wrapper] Warning: seccomp not applied: %v\n", err)
+				// Non-fatal: continue without syscall filtering.
+			}
 		}
 	}
 

--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -55,6 +55,8 @@ var (
 	allowDests             []string
 	blankProfile           bool
 	noBwrap                bool
+	netnsPath              string
+	netnsHelperPath        string
 )
 
 func main() {
@@ -128,6 +130,8 @@ Configuration file format:
 	rootCmd.Flags().BoolVar(&linuxFeatures, "linux-features", false, "Show available Linux security features and exit")
 	rootCmd.Flags().BoolVar(&learning, "learning", false, "Run in learning mode: trace filesystem access and generate a config profile")
 	rootCmd.Flags().BoolVar(&noBwrap, "no-bwrap", false, "Skip bubblewrap; enforce via Landlock + seccomp only (for nested-Docker environments where bwrap cannot create user namespaces)")
+	rootCmd.Flags().StringVar(&netnsPath, "netns", "", "Run the wrapped command inside a pre-built netns (from greywall-netns-helper create). Pairs with --no-bwrap.")
+	rootCmd.Flags().StringVar(&netnsHelperPath, "netns-helper", "", "Path to greywall-netns-helper (default: look up in PATH)")
 	rootCmd.Flags().StringVar(&profileName, "profile", "", "Load profiles by name, comma-separated (e.g. --profile claude,uv)")
 	rootCmd.Flags().BoolVar(&noNetworkRules, "no-network-rules", false, "Skip applying profile network rules to greyproxy (filesystem + keyring still apply)")
 	rootCmd.Flags().BoolVar(&autoProfile, "auto-profile", false, "Use saved or built-in profile without prompting")
@@ -385,6 +389,15 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		manager.SetNoBwrap(true)
 		if debug {
 			fmt.Fprintf(os.Stderr, "[greywall] --no-bwrap mode: Landlock + seccomp only, no namespaces\n")
+		}
+	}
+	if netnsPath != "" {
+		if !noBwrap {
+			return fmt.Errorf("--netns requires --no-bwrap (bwrap creates its own netns)")
+		}
+		manager.SetNetns(netnsPath, netnsHelperPath)
+		if debug {
+			fmt.Fprintf(os.Stderr, "[greywall] --netns=%s: wrapped command will run inside pre-built netns\n", netnsPath)
 		}
 	}
 	defer manager.Cleanup()

--- a/internal/sandbox/linux_nobwrap.go
+++ b/internal/sandbox/linux_nobwrap.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/GreyhavenHQ/greywall/internal/config"
+)
+
+// WrapCommandLinuxNoBwrap produces a command string for --no-bwrap mode.
+//
+// Instead of building a bubblewrap invocation, this path generates a small
+// shell script that:
+//  1. Exports GREYWALL_CONFIG_JSON so the --landlock-apply wrapper picks up
+//     the same config the parent greywall process resolved.
+//  2. Exports ALL_PROXY / HTTP_PROXY / HTTPS_PROXY when the config declares a
+//     SOCKS5 or HTTP proxy. This is the env-var-based fallback — the wrapped
+//     command has no network namespace, so well-behaved HTTP clients honor
+//     the proxy env, but raw sockets will *not* be forced through it. For
+//     kernel-enforced capture, combine with a pre-built netns (--netns).
+//  3. Execs `greywall --landlock-apply --seccomp -- bash -c "<cmd>"`, which
+//     applies Landlock + seccomp to the current process then execs the user
+//     command.
+//
+// Intended for nested-Docker environments where bwrap cannot create user
+// namespaces (uid_map write blocked by the host's LinuxKit VM).
+func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool) (string, error) {
+	greywallExePath, err := os.Executable()
+	if err != nil || greywallExePath == "" {
+		return "", fmt.Errorf("no-bwrap: cannot resolve greywall executable path: %w", err)
+	}
+
+	var script strings.Builder
+
+	if cfg != nil {
+		configJSON, err := json.Marshal(cfg)
+		if err == nil {
+			fmt.Fprintf(&script, "export GREYWALL_CONFIG_JSON=%s\n",
+				ShellQuoteSingle(string(configJSON)))
+		}
+
+		if cfg.Network.ProxyURL != "" {
+			fmt.Fprintf(&script, "export ALL_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+			fmt.Fprintf(&script, "export HTTPS_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+			fmt.Fprintf(&script, "export https_proxy=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+		}
+		if cfg.Network.HTTPProxyURL != "" {
+			fmt.Fprintf(&script, "export HTTP_PROXY=%s\n", ShellQuoteSingle(cfg.Network.HTTPProxyURL))
+			fmt.Fprintf(&script, "export http_proxy=%s\n", ShellQuoteSingle(cfg.Network.HTTPProxyURL))
+		} else if cfg.Network.ProxyURL != "" {
+			fmt.Fprintf(&script, "export HTTP_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+			fmt.Fprintf(&script, "export http_proxy=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+		}
+	}
+
+	wrapperArgs := []string{greywallExePath, "--landlock-apply", "--seccomp"}
+	if debug {
+		wrapperArgs = append(wrapperArgs, "--debug")
+	}
+	wrapperArgs = append(wrapperArgs, "--", "bash", "-c", command)
+
+	fmt.Fprintf(&script, "exec %s\n", ShellQuote(wrapperArgs))
+
+	return script.String(), nil
+}

--- a/internal/sandbox/linux_nobwrap.go
+++ b/internal/sandbox/linux_nobwrap.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/GreyhavenHQ/greywall/internal/config"
@@ -28,10 +29,25 @@ import (
 //
 // Intended for nested-Docker environments where bwrap cannot create user
 // namespaces (uid_map write blocked by the host's LinuxKit VM).
-func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool) (string, error) {
+//
+// When netnsPath is non-empty, the wrapped command is run inside that
+// pre-built netns (created by `greywall-netns-helper create`). netnsHelper
+// overrides the helper binary path; empty means look up in PATH.
+func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool, netnsPath, netnsHelper string) (string, error) {
 	greywallExePath, err := os.Executable()
 	if err != nil || greywallExePath == "" {
 		return "", fmt.Errorf("no-bwrap: cannot resolve greywall executable path: %w", err)
+	}
+
+	var helperBin string
+	if netnsPath != "" {
+		if netnsHelper != "" {
+			helperBin = netnsHelper
+		} else if resolved, err := exec.LookPath("greywall-netns-helper"); err == nil {
+			helperBin = resolved
+		} else {
+			return "", fmt.Errorf("no-bwrap: --netns set but greywall-netns-helper not found in PATH (use --netns-helper)")
+		}
 	}
 
 	var script strings.Builder
@@ -43,17 +59,23 @@ func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool) (st
 				ShellQuoteSingle(string(configJSON)))
 		}
 
-		if cfg.Network.ProxyURL != "" {
-			fmt.Fprintf(&script, "export ALL_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
-			fmt.Fprintf(&script, "export HTTPS_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
-			fmt.Fprintf(&script, "export https_proxy=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
-		}
-		if cfg.Network.HTTPProxyURL != "" {
-			fmt.Fprintf(&script, "export HTTP_PROXY=%s\n", ShellQuoteSingle(cfg.Network.HTTPProxyURL))
-			fmt.Fprintf(&script, "export http_proxy=%s\n", ShellQuoteSingle(cfg.Network.HTTPProxyURL))
-		} else if cfg.Network.ProxyURL != "" {
-			fmt.Fprintf(&script, "export HTTP_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
-			fmt.Fprintf(&script, "export http_proxy=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+		// Env-var proxy is only useful as a fallback when there's no netns;
+		// inside a netns all traffic goes through tun2socks anyway, and
+		// well-behaved HTTP clients that see ALL_PROXY would double-proxy
+		// through an unreachable localhost port.
+		if netnsPath == "" {
+			if cfg.Network.ProxyURL != "" {
+				fmt.Fprintf(&script, "export ALL_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+				fmt.Fprintf(&script, "export HTTPS_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+				fmt.Fprintf(&script, "export https_proxy=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+			}
+			if cfg.Network.HTTPProxyURL != "" {
+				fmt.Fprintf(&script, "export HTTP_PROXY=%s\n", ShellQuoteSingle(cfg.Network.HTTPProxyURL))
+				fmt.Fprintf(&script, "export http_proxy=%s\n", ShellQuoteSingle(cfg.Network.HTTPProxyURL))
+			} else if cfg.Network.ProxyURL != "" {
+				fmt.Fprintf(&script, "export HTTP_PROXY=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+				fmt.Fprintf(&script, "export http_proxy=%s\n", ShellQuoteSingle(cfg.Network.ProxyURL))
+			}
 		}
 	}
 
@@ -63,7 +85,16 @@ func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool) (st
 	}
 	wrapperArgs = append(wrapperArgs, "--", "bash", "-c", command)
 
-	fmt.Fprintf(&script, "exec %s\n", ShellQuote(wrapperArgs))
+	if netnsPath != "" {
+		// Prefix with the setcap'd helper so the exec chain enters the
+		// netns and drops all caps before handing off to the landlock
+		// wrapper. The helper's exec subcommand validates the path is
+		// under /run/greywall.
+		fullChain := append([]string{helperBin, "exec", "--netns", netnsPath, "--"}, wrapperArgs...)
+		fmt.Fprintf(&script, "exec %s\n", ShellQuote(fullChain))
+	} else {
+		fmt.Fprintf(&script, "exec %s\n", ShellQuote(wrapperArgs))
+	}
 
 	return script.String(), nil
 }

--- a/internal/sandbox/linux_seccomp.go
+++ b/internal/sandbox/linux_seccomp.go
@@ -88,17 +88,11 @@ func (s *SeccompFilter) GenerateBPFFilter() (string, error) {
 	return filterPath, nil
 }
 
-// writeBPFProgram writes a BPF program that blocks dangerous syscalls.
-// This generates a compact BPF program in the format expected by bwrap --seccomp.
-func (s *SeccompFilter) writeBPFProgram(path string) error {
-	// For bwrap, we need to pass the seccomp filter via file descriptor
-	// The filter format is: struct sock_filter array
-	//
-	// We'll build a simple filter:
-	// 1. Load syscall number
-	// 2. For each dangerous syscall: if match, return ERRNO(EPERM) or LOG+ERRNO
-	// 3. Default: allow
-
+// generateBPFInstructions builds the BPF program that blocks dangerous syscalls
+// and returns it as an in-memory slice of sock_filter instructions. Used both by
+// writeBPFProgram (file format for bwrap --seccomp) and by ApplySeccompFilter
+// (direct SECCOMP_SET_MODE_FILTER load in --no-bwrap mode).
+func generateBPFInstructions() ([]bpfInstruction, error) {
 	// Get syscall numbers for the current architecture
 	syscallNums := make(map[string]int)
 	for _, name := range DangerousSyscalls {
@@ -109,7 +103,7 @@ func (s *SeccompFilter) writeBPFProgram(path string) error {
 
 	if len(syscallNums) == 0 {
 		// No syscalls to block (unknown architecture?)
-		return fmt.Errorf("no syscall numbers found for dangerous syscalls")
+		return nil, fmt.Errorf("no syscall numbers found for dangerous syscalls")
 	}
 
 	// Build BPF program
@@ -199,7 +193,17 @@ func (s *SeccompFilter) writeBPFProgram(path string) error {
 		k:    SECCOMP_RET_ALLOW,
 	})
 
-	// Write the program to file
+	return program, nil
+}
+
+// writeBPFProgram writes a BPF program that blocks dangerous syscalls.
+// This generates a compact BPF program in the format expected by bwrap --seccomp.
+func (s *SeccompFilter) writeBPFProgram(path string) error {
+	program, err := generateBPFInstructions()
+	if err != nil {
+		return err
+	}
+
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // path is controlled
 	if err != nil {
 		return err

--- a/internal/sandbox/linux_seccomp_apply.go
+++ b/internal/sandbox/linux_seccomp_apply.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// sockFilter mirrors struct sock_filter from linux/filter.h.
+// Layout must match exactly: 2-byte code, 1-byte jt, 1-byte jf, 4-byte k.
+type sockFilter struct {
+	code uint16
+	jt   uint8
+	jf   uint8
+	k    uint32
+}
+
+// sockFprog mirrors struct sock_fprog from linux/filter.h.
+type sockFprog struct {
+	len    uint16
+	_      [6]byte // padding so filter is 8-aligned on 64-bit
+	filter *sockFilter
+}
+
+// SECCOMP_SET_MODE_FILTER is the op for the seccomp() syscall that loads
+// a classic BPF filter. See include/uapi/linux/seccomp.h.
+const SECCOMP_SET_MODE_FILTER = 1
+
+// ApplySeccompFilter loads the same BPF program greywall normally hands to
+// bwrap --seccomp, but loads it directly into the current process via
+// prctl(PR_SET_NO_NEW_PRIVS) + seccomp(SECCOMP_SET_MODE_FILTER, ...). This
+// allows --no-bwrap mode to enforce syscall restrictions without any
+// namespace magic.
+//
+// PR_SET_NO_NEW_PRIVS may already have been set by Landlock's Apply(); that's
+// fine — prctl is idempotent. Calling it here too keeps this function safe to
+// use standalone (without Landlock).
+func ApplySeccompFilter(debug bool) error {
+	program, err := generateBPFInstructions()
+	if err != nil {
+		return fmt.Errorf("seccomp: failed to generate BPF program: %w", err)
+	}
+
+	// Convert our internal representation to struct sock_filter.
+	filter := make([]sockFilter, len(program))
+	for i, inst := range program {
+		filter[i] = sockFilter{
+			code: inst.code,
+			jt:   inst.jt,
+			jf:   inst.jf,
+			k:    inst.k,
+		}
+	}
+
+	// PR_SET_NO_NEW_PRIVS is a prerequisite for loading a seccomp filter as
+	// an unprivileged process. Idempotent — Landlock may already have set it.
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("seccomp: PR_SET_NO_NEW_PRIVS failed: %w", err)
+	}
+
+	prog := sockFprog{
+		len:    uint16(len(filter)), //nolint:gosec // len bounded by DangerousSyscalls size
+		filter: &filter[0],
+	}
+
+	_, _, errno := unix.Syscall(
+		unix.SYS_SECCOMP,
+		SECCOMP_SET_MODE_FILTER,
+		0, // flags
+		uintptr(unsafe.Pointer(&prog)), //nolint:gosec // required for syscall
+	)
+	if errno != 0 {
+		return fmt.Errorf("seccomp(SECCOMP_SET_MODE_FILTER) failed: %w", errno)
+	}
+
+	if debug {
+		fmt.Fprintf(os.Stderr, "[greywall:seccomp] Loaded filter directly (%d instructions, %d syscalls blocked)\n",
+			len(filter), len(DangerousSyscalls))
+	}
+
+	return nil
+}

--- a/internal/sandbox/linux_seccomp_apply_stub.go
+++ b/internal/sandbox/linux_seccomp_apply_stub.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package sandbox
+
+// ApplySeccompFilter is a no-op on non-Linux platforms.
+func ApplySeccompFilter(debug bool) error {
+	return nil
+}

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -102,7 +102,7 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 }
 
 // WrapCommandLinuxNoBwrap returns an error on non-Linux platforms.
-func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool) (string, error) {
+func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool, netnsPath, netnsHelper string) (string, error) {
 	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -101,6 +101,11 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
+// WrapCommandLinuxNoBwrap returns an error on non-Linux platforms.
+func WrapCommandLinuxNoBwrap(cfg *config.Config, command string, debug bool) (string, error) {
+	return "", fmt.Errorf("linux sandbox not available on this platform")
+}
+
 // StartLinuxMonitor returns nil on non-Linux platforms.
 func StartLinuxMonitor(pid int, opts LinuxSandboxOptions) (*LinuxMonitors, error) {
 	return nil, nil

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -25,6 +25,8 @@ type Manager struct {
 	initialized   bool
 	learning      bool   // learning mode: permissive sandbox with strace/eslogger
 	noBwrap       bool   // --no-bwrap: skip bubblewrap, rely on Landlock + seccomp only
+	netnsPath     string // --netns: pre-built netns to enter (requires noBwrap)
+	netnsHelper   string // override path to greywall-netns-helper
 	straceLogPath string // host-side temp file for strace output (Linux)
 	commandName   string // name of the command being learned
 	// macOS learning mode fields
@@ -64,6 +66,14 @@ func (m *Manager) SetNoBwrap(enabled bool) {
 // IsNoBwrap returns whether --no-bwrap mode is active.
 func (m *Manager) IsNoBwrap() bool {
 	return m.noBwrap
+}
+
+// SetNetns points the --no-bwrap path at a pre-built netns (created by
+// greywall-netns-helper create). helperPath is optional; empty string means
+// look up greywall-netns-helper in $PATH.
+func (m *Manager) SetNetns(netnsPath, helperPath string) {
+	m.netnsPath = netnsPath
+	m.netnsHelper = helperPath
 }
 
 // SetCommandName sets the command name for learning mode profile generation.
@@ -273,7 +283,7 @@ func (m *Manager) WrapCommand(command string) (string, error) {
 			return m.wrapCommandLearning(command)
 		}
 		if m.noBwrap {
-			return WrapCommandLinuxNoBwrap(m.config, command, m.debug)
+			return WrapCommandLinuxNoBwrap(m.config, command, m.debug, m.netnsPath, m.netnsHelper)
 		}
 		return WrapCommandLinuxWithOptions(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.forwardBridge, m.dbusBridge, m.tun2socksPath, LinuxSandboxOptions{
 			UseLandlock:       true,

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -24,6 +24,7 @@ type Manager struct {
 	monitor       bool
 	initialized   bool
 	learning      bool   // learning mode: permissive sandbox with strace/eslogger
+	noBwrap       bool   // --no-bwrap: skip bubblewrap, rely on Landlock + seccomp only
 	straceLogPath string // host-side temp file for strace output (Linux)
 	commandName   string // name of the command being learned
 	// macOS learning mode fields
@@ -50,6 +51,19 @@ func (m *Manager) SetExposedPorts(ports []int) {
 // SetLearning enables or disables learning mode.
 func (m *Manager) SetLearning(enabled bool) {
 	m.learning = enabled
+}
+
+// SetNoBwrap enables --no-bwrap mode. When set, WrapCommand (Linux) skips
+// bubblewrap entirely and produces a command that applies Landlock + seccomp
+// directly via the --landlock-apply wrapper. Intended for nested-Docker
+// environments where bwrap fails on uid_map writes.
+func (m *Manager) SetNoBwrap(enabled bool) {
+	m.noBwrap = enabled
+}
+
+// IsNoBwrap returns whether --no-bwrap mode is active.
+func (m *Manager) IsNoBwrap() bool {
+	return m.noBwrap
 }
 
 // SetCommandName sets the command name for learning mode profile generation.
@@ -136,8 +150,12 @@ func (m *Manager) Initialize() error {
 		return nil
 	}
 
-	// On Linux, set up proxy bridge and tun2socks if proxy is configured
-	if platform.Detect() == platform.Linux {
+	// On Linux, set up proxy bridge and tun2socks if proxy is configured.
+	// In --no-bwrap mode, we don't bind Unix sockets into a sandbox (no bwrap),
+	// and we don't set up a netns for tun2socks — the wrapped command relies on
+	// the env-var proxy injection in linux_nobwrap.go. Skip the bridges entirely
+	// so we don't require socat in environments that can't use bwrap anyway.
+	if platform.Detect() == platform.Linux && !m.noBwrap {
 		if m.config.Network.ProxyURL != "" {
 			// Extract embedded tun2socks binary
 			tun2socksPath, err := extractTun2Socks()
@@ -253,6 +271,9 @@ func (m *Manager) WrapCommand(command string) (string, error) {
 	case platform.Linux:
 		if m.learning {
 			return m.wrapCommandLearning(command)
+		}
+		if m.noBwrap {
+			return WrapCommandLinuxNoBwrap(m.config, command, m.debug)
 		}
 		return WrapCommandLinuxWithOptions(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.forwardBridge, m.dbusBridge, m.tun2socksPath, LinuxSandboxOptions{
 			UseLandlock:       true,


### PR DESCRIPTION
Draft. Three stacked commits that together make greywall usable in environments where bubblewrap cannot create user namespaces — most notably inside Docker (including Docker Desktop) running as a non-root user, where `uid_map` writes are blocked by the host kernel regardless of `cap_add SYS_ADMIN + seccomp=unconfined + apparmor=unconfined`. See [containers/bubblewrap#505](https://github.com/containers/bubblewrap/issues/505) for the underlying limitation.

Each commit stands on its own feature; they are filed together because the later ones depend on the first. Happy to split if that makes review easier.

## Commits

### 1. `feat: --no-bwrap mode for nested-Docker / rootless environments` (7c10e28)

Adds a `--no-bwrap` flag that skips bubblewrap entirely and enforces the sandbox using primitives that work for an unprivileged process:

- **Landlock** — reused from the existing `--landlock-apply` wrapper.
- **seccomp-bpf** — new direct loader via `prctl(PR_SET_NO_NEW_PRIVS) + seccomp(SECCOMP_SET_MODE_FILTER)` in a new `internal/sandbox/linux_seccomp_apply.go`. The existing `generateBPFInstructions()` was factored out of `writeBPFProgram` so both the file-writing path (bwrap `--seccomp 3`) and the direct-load path can share it.
- **env-var SOCKS5/HTTP proxy** — `WrapCommandLinuxNoBwrap` (new file) emits the proxy URL via `ALL_PROXY` / `HTTPS_PROXY` instead of bwrap's tun2socks. Fine for well-behaved HTTP clients; raw-socket bypass is possible at this layer (commit #2 addresses that).

Files:
```
cmd/greywall/main.go                         +33
internal/sandbox/linux_nobwrap.go            +69 (new)
internal/sandbox/linux_seccomp.go            +30 / −18 (refactor)
internal/sandbox/linux_seccomp_apply.go      +86 (new)
internal/sandbox/linux_seccomp_apply_stub.go  +8 (new)
internal/sandbox/linux_stub.go                +5
internal/sandbox/manager.go                  +25
```

Behaviour when `--no-bwrap` is unset: unchanged.

### 2. `feat: greywall-netns-helper + --netns flag for transparent capture` (5de0788)

Adds a separate helper binary `greywall-netns-helper` (installed with `setcap cap_net_admin,cap_sys_admin+ep`, never root) that:

- **`create --proxy URL`** — `unshare(CLONE_NEWNET)`, bring up `tun0` at 198.18.0.1/15, set default route via tun0, launch the existing embedded `tun2socks` inside the netns pointed at the SOCKS5 proxy, bind-mount `/proc/self/ns/net` to `/run/greywall/ns-<uuid>` to pin it, print the pin path, exit.
- **`exec --netns PATH -- CMD`** — `setns` into the pin, drop all caps (effective + permitted + inheritable + ambient + bounding set), `syscall.Exec` the user command. Rejects paths outside `/run/greywall` so the file caps can't be leveraged to enter arbitrary netns.
- **`destroy PATH`** — SIGTERM the recorded tun2socks pid, unmount and remove the pin.

The main greywall binary gets a paired `--netns <path>` flag that, when combined with `--no-bwrap`, prefixes the command chain with `greywall-netns-helper exec --netns <path> --` so the wrapped process enters the prepared netns before Landlock/seccomp are applied.

Result: kernel-enforced egress capture (every TCP/UDP packet goes through tun0 → tun2socks → SOCKS5) without requiring the wrapped process to hold any capabilities and without relying on it honoring proxy env vars. Raw sockets are no longer a bypass.

Ambient-caps dance for `CAP_NET_ADMIN` is used so `ip`/`tun2socks` children of the helper inherit the capability without the helper having to reimplement the netlink calls in Go.

### 3. `feat(netns-helper): --bridge-port` (e735ca7)

Optional `--bridge-port N` flag on `create` that makes a TCP server inside the netns reachable from the host netns (typical use: a sandboxed server whose API is consumed by a trusted host-netns orchestrator). Mechanism:

- **Inside netns**: socat `UNIX-LISTEN:<pin>.sock → TCP:127.0.0.1:N`
- **Host netns** (sibling spawned *before* `unshare`): socat `TCP4-LISTEN:N,bind=127.0.0.1 → UNIX-CONNECT:<pin>.sock`
- The shared Unix socket lives on the regular filesystem, so it crosses the netns boundary transparently.

`destroy` now reads a multi-line PID sidecar (`<pin>.pid` carrying tun2socks + both socat pids) and SIGTERMs every recorded pid. The `_bridge-host` internal subcommand validates that the socket path sits alongside a valid pin so the file caps can't be abused to proxy arbitrary Unix sockets.

## Security notes

- The main greywall binary stays uncap'd; all privileged setup is isolated to the tiny `greywall-netns-helper` binary.
- `greywall-netns-helper exec` validates its `--netns` path is under `/run/greywall/` and drops every cap set (effective, permitted, inheritable, ambient, bounding) before `syscall.Exec`.
- `greywall-netns-helper _bridge-host` (internal) validates its `--socket` path similarly.
- File caps (`cap_net_admin,cap_sys_admin+ep`) are the principle of least privilege for the helper: `CAP_SYS_ADMIN` is required to `unshare(CLONE_NEWNET)` and `setns`; `CAP_NET_ADMIN` for `ip tuntap/addr/link/route`. Nothing else.

## Install delta

- Linux: package dependencies gain `iproute2` (the `ip` tool) and `libcap2-bin` (at install-time, for `setcap`). `tun2socks` binary is already embedded in the greywall source tree for amd64/arm64.
- A writable `/run/greywall/` directory owned by the invoking user must exist at runtime (helper does not attempt to chown). Suggested deployment: `mkdir -p /run/greywall && chown $USER:$USER /run/greywall`, or a systemd-tmpfiles drop-in.

## Testing

All three commits verified end-to-end inside a plain `python:3.12-slim` Docker container running as a non-root user with the usual `cap_add SYS_ADMIN NET_ADMIN` + `security_opt seccomp=unconfined apparmor=unconfined`:

- `--no-bwrap` alone: wrapped process has `uid=1000, CapEff=0, NoNewPrivs=1, Seccomp=2, Seccomp_filters=1`, Landlock rules enforced (write to `/etc` → EACCES), write to cwd allowed.
- `--no-bwrap --netns <pin>`: same sandbox state plus the process netns differs from the host netns; `ip -br link` inside shows only `lo + tun0`, `eth0` not visible.
- `--bridge-port 4096`: a host-netns client connects to `127.0.0.1:4096` and talks to an HTTP server bound at `127.0.0.1:4096` inside the netns; round-trip confirmed with a standard health-check response.
- Cleanup on `destroy`: all three pids (tun2socks + 2 socat) are gone, pin + .sock + .pid files unlinked.

Builds clean on `go build ./...` and `GOOS=linux GOARCH=arm64 go build ./...`.

## Test plan

- [x] `go build ./...` on darwin/arm64
- [x] `GOOS=linux GOARCH=arm64 go build ./...`
- [x] `--no-bwrap -- <cmd>` as non-root user in Docker → Landlock + seccomp applied
- [x] `greywall-netns-helper create` → netns pinned, tun2socks up, helper exits cleanly
- [x] `greywall --no-bwrap --netns <pin> -- <cmd>` → child runs in isolated netns with no caps
- [x] `greywall-netns-helper destroy` → all pids SIGTERM'd, files cleaned up
- [x] `--bridge-port N` → bidirectional TCP reachable from host netns
- [ ] Cross-review of the setcap'd helper's security posture by maintainers