### PR TITLE
Fix/macos per session tmpdir

### DIFF
--- a/internal/profiles/agents/claude.go
+++ b/internal/profiles/agents/claude.go
@@ -1,6 +1,8 @@
 package agents
 
 import (
+	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/GreyhavenHQ/greywall/internal/config"
@@ -37,6 +39,12 @@ func init() {
 					"/Library/Application Support/ClaudeCode/managed-mcp.json",
 					"/Library/Application Support/ClaudeCode/CLAUDE.md",
 				)
+				// Claude Code creates its bash working-directory under
+				// /private/tmp/claude-{uid}/ regardless of $TMPDIR.
+				uid := os.Getuid()
+				claudeTmp := fmt.Sprintf("/private/tmp/claude-%d", uid)
+				allowRead = append(allowRead, claudeTmp, "/tmp/claude-"+fmt.Sprint(uid))
+				allowWrite = append(allowWrite, claudeTmp, "/tmp/claude-"+fmt.Sprint(uid))
 			}
 			return &config.Config{
 				Network: config.NetworkConfig{

--- a/internal/profiles/agents/claude.go
+++ b/internal/profiles/agents/claude.go
@@ -1,8 +1,6 @@
 package agents
 
 import (
-	"fmt"
-	"os"
 	"runtime"
 
 	"github.com/GreyhavenHQ/greywall/internal/config"
@@ -38,13 +36,16 @@ func init() {
 					"/Library/Application Support/ClaudeCode/managed-settings.json",
 					"/Library/Application Support/ClaudeCode/managed-mcp.json",
 					"/Library/Application Support/ClaudeCode/CLAUDE.md",
+					// Claude Code creates session dirs under /private/tmp/claude-{uid}/
+					// and a working-dir tracker at /tmp/claude-{pid}-cwd. Both use
+					// numeric suffixes (UID or PID) that vary per user/run.
+					"/tmp/claude-*",
+					"/tmp/claude-*/**",
 				)
-				// Claude Code creates its bash working-directory under
-				// /private/tmp/claude-{uid}/ regardless of $TMPDIR.
-				uid := os.Getuid()
-				claudeTmp := fmt.Sprintf("/private/tmp/claude-%d", uid)
-				allowRead = append(allowRead, claudeTmp, "/tmp/claude-"+fmt.Sprint(uid))
-				allowWrite = append(allowWrite, claudeTmp, "/tmp/claude-"+fmt.Sprint(uid))
+				allowWrite = append(allowWrite,
+					"/tmp/claude-*",
+					"/tmp/claude-*/**",
+				)
 			}
 			return &config.Config{
 				Network: config.NetworkConfig{

--- a/internal/sandbox/dangerous.go
+++ b/internal/sandbox/dangerous.go
@@ -70,8 +70,6 @@ func GetDefaultWritePaths() []string {
 		"/dev/tty",
 		"/dev/dtracehelper",
 		"/dev/autofs_nowait",
-		"/tmp/greywall",
-		"/private/tmp/greywall",
 	}
 
 	if home != "" {

--- a/internal/sandbox/dangerous_test.go
+++ b/internal/sandbox/dangerous_test.go
@@ -14,7 +14,7 @@ func TestGetDefaultWritePaths(t *testing.T) {
 		t.Error("GetDefaultWritePaths() returned empty slice")
 	}
 
-	essentialPaths := []string{"/dev/stdout", "/dev/stderr", "/dev/null", "/tmp/greywall"}
+	essentialPaths := []string{"/dev/stdout", "/dev/stderr", "/dev/null"}
 	for _, essential := range essentialPaths {
 		found := slices.Contains(paths, essential)
 		if !found {

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -144,23 +144,21 @@ func TestMacOS_SeatbeltBlocksWriteSystemFiles(t *testing.T) {
 	assertFileNotExists(t, "/etc/greywall-test-file")
 }
 
-// TestMacOS_SeatbeltAllowsTmpGreywall verifies /tmp/greywall is writable.
-func TestMacOS_SeatbeltAllowsTmpGreywall(t *testing.T) {
+// TestMacOS_SeatbeltAllowsPerSessionTmpDir verifies that the per-session TMPDIR
+// created by Manager.Initialize is writable inside the sandbox.
+func TestMacOS_SeatbeltAllowsPerSessionTmpDir(t *testing.T) {
 	skipIfAlreadySandboxed(t)
 
 	workspace := createTempWorkspace(t)
 	cfg := testConfigWithWorkspace(workspace)
 
-	// Ensure /tmp/greywall exists
-	_ = os.MkdirAll("/tmp/greywall", 0o750)
-
-	testFile := "/tmp/greywall/test-file-" + filepath.Base(workspace)
-	defer func() { _ = os.Remove(testFile) }()
-
-	result := runUnderSandbox(t, cfg, "echo 'test' > "+testFile, workspace)
+	// Write to $TMPDIR/test-file and verify it succeeds.
+	// The manager injects TMPDIR pointing to the per-session dir, so
+	// $TMPDIR resolves to a path the sandbox allows.
+	result := runUnderSandbox(t, cfg, "echo 'test' > $TMPDIR/greywall-sandbox-test && cat $TMPDIR/greywall-sandbox-test", workspace)
 
 	assertAllowed(t, result)
-	assertFileExists(t, testFile)
+	assertContains(t, result.Stdout, "test")
 }
 
 // ============================================================================

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -669,11 +669,15 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 }
 
 // WrapCommandMacOS wraps a command with macOS sandbox restrictions.
-func WrapCommandMacOS(cfg *config.Config, command string, exposedPorts []int, rewrittenEnvFiles map[string]string, debug bool) (string, error) {
+// tmpDir is the per-session temp directory to set as TMPDIR; if empty, TMPDIR is not overridden.
+func WrapCommandMacOS(cfg *config.Config, command string, exposedPorts []int, rewrittenEnvFiles map[string]string, tmpDir string, debug bool) (string, error) {
 	cwd, _ := os.Getwd()
 
-	// Build allow paths: default + configured
+	// Build allow paths: default + configured + per-session tmpdir
 	allowPaths := append(GetDefaultWritePaths(), cfg.Filesystem.AllowWrite...)
+	if tmpDir != "" {
+		allowPaths = append(allowPaths, tmpDir)
+	}
 
 	// Expand /tmp <-> /private/tmp for macOS symlink compatibility
 	allowPaths = expandMacOSTmpPaths(allowPaths)
@@ -760,7 +764,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, exposedPorts []int, re
 		return "", fmt.Errorf("shell %q not found: %w", shell, err)
 	}
 
-	proxyEnvs := GenerateProxyEnvVars(cfg.Network.ProxyURL, cfg.Network.HTTPProxyURL)
+	proxyEnvs := GenerateProxyEnvVars(cfg.Network.ProxyURL, cfg.Network.HTTPProxyURL, tmpDir)
 
 	// Build the command
 	// env VAR1=val1 VAR2=val2 sandbox-exec -p 'profile' shell -c 'command'

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -31,6 +31,7 @@ type Manager struct {
 	esloggerLogPath   string            // temp file for eslogger output (macOS)
 	esloggerCmd       *exec.Cmd         // eslogger subprocess (macOS)
 	rewrittenEnvFiles map[string]string // original path -> temp path with credential placeholders
+	macOSTmpDir       string            // per-session TMPDIR created on macOS (cleaned up on exit)
 }
 
 // NewManager creates a new sandbox manager.
@@ -215,6 +216,19 @@ func (m *Manager) Initialize() error {
 		m.dbusBridge = NewDbusBridge(m.debug)
 	}
 
+	// On macOS (non-learning), create a per-session temp directory and expose it
+	// as TMPDIR inside the sandbox. This avoids the need to allow arbitrary writes
+	// to /private/tmp, while giving sandboxed processes a working temp directory.
+	if platform.Detect() == platform.MacOS && !m.learning {
+		tmpDir, err := os.MkdirTemp("", "greywall-")
+		if err != nil {
+			m.logDebug("warning: failed to create per-session TMPDIR: %v", err)
+		} else {
+			m.macOSTmpDir = tmpDir
+			m.logDebug("Created per-session TMPDIR: %s", tmpDir)
+		}
+	}
+
 	m.initialized = true
 	if m.config.Network.ProxyURL != "" {
 		dnsInfo := "none"
@@ -249,7 +263,7 @@ func (m *Manager) WrapCommand(command string) (string, error) {
 			// In learning mode, run command directly (no sandbox-exec wrapping)
 			return command, nil
 		}
-		return WrapCommandMacOS(m.config, command, m.exposedPorts, m.rewrittenEnvFiles, m.debug)
+		return WrapCommandMacOS(m.config, command, m.exposedPorts, m.rewrittenEnvFiles, m.macOSTmpDir, m.debug)
 	case platform.Linux:
 		if m.learning {
 			return m.wrapCommandLearning(command)
@@ -337,6 +351,10 @@ func (m *Manager) Cleanup() {
 	if m.esloggerLogPath != "" {
 		_ = os.Remove(m.esloggerLogPath)
 		m.esloggerLogPath = ""
+	}
+	if m.macOSTmpDir != "" {
+		_ = os.RemoveAll(m.macOSTmpDir)
+		m.macOSTmpDir = ""
 	}
 	m.logDebug("Sandbox manager cleaned up")
 }

--- a/internal/sandbox/utils.go
+++ b/internal/sandbox/utils.go
@@ -51,10 +51,11 @@ func NormalizePath(pathPattern string) string {
 // GenerateProxyEnvVars creates environment variables for proxy configuration.
 // Used on macOS where transparent proxying is not available.
 // proxyURL is the SOCKS5 proxy (for ALL_PROXY), httpProxyURL is the HTTP CONNECT proxy (for HTTP_PROXY/HTTPS_PROXY).
-func GenerateProxyEnvVars(proxyURL, httpProxyURL string) []string {
-	envVars := []string{
-		"GREYWALL_SANDBOX=1",
-		"TMPDIR=/tmp/greywall",
+// tmpDir is the per-session temporary directory to expose as TMPDIR; if empty, TMPDIR is not overridden.
+func GenerateProxyEnvVars(proxyURL, httpProxyURL, tmpDir string) []string {
+	envVars := []string{"GREYWALL_SANDBOX=1"}
+	if tmpDir != "" {
+		envVars = append(envVars, "TMPDIR="+tmpDir)
 	}
 
 	if proxyURL == "" && httpProxyURL == "" {

--- a/internal/sandbox/utils_test.go
+++ b/internal/sandbox/utils_test.go
@@ -137,7 +137,7 @@ func TestGenerateProxyEnvVars(t *testing.T) {
 			httpProxyURL: "",
 			wantEnvs: []string{
 				"GREYWALL_SANDBOX=1",
-				"TMPDIR=/tmp/greywall",
+				"TMPDIR=/tmp/test-greywall",
 			},
 			dontWant: []string{
 				"HTTP_PROXY=",
@@ -200,7 +200,7 @@ func TestGenerateProxyEnvVars(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateProxyEnvVars(tt.proxyURL, tt.httpProxyURL)
+			got := GenerateProxyEnvVars(tt.proxyURL, tt.httpProxyURL, "/tmp/test-greywall")
 
 			// Check expected env vars are present
 			for _, want := range tt.wantEnvs {


### PR DESCRIPTION
# fix(macos): per-session TMPDIR and Claude Code bash working-dir access

Closes #11

## Problem

On macOS, sandboxed processes were silently failing to write to `/tmp` because
the static path `greywall` injected (`TMPDIR=/tmp/greywall`) was never actually
created, so processes fell back to `/private/tmp` — which the Seatbelt policy
denied.

For the `claude` profile specifically this caused two distinct failures:

1. **Session directory blocked** — Claude Code hardcodes
   `/private/tmp/claude-{uid}/{encoded-cwd}` as its bash session directory,
   ignoring `$TMPDIR` entirely. Any bash tool call resulted in:
   ```
   EPERM: operation not permitted, mkdir '/private/tmp/claude-501/...'
   ```

2. **Working-dir tracker blocked** — Claude Code also creates
   `/tmp/claude-{pid}-cwd` to persist the working directory between commands.
   The PID suffix changes every run, so a UID-specific allow rule wasn't enough:
   ```
   zsh: operation not permitted: /tmp/claude-2522-cwd
   ```

## Fix

**Per-session TMPDIR** (`manager.go`, `macos.go`, `utils.go`, `dangerous.go`)

Instead of injecting a static `TMPDIR` path that may not exist, `Manager.Initialize()`
now calls `os.MkdirTemp("", "greywall-")` on macOS. This creates a real directory
inside the system's `$TMPDIR` (`/var/folders/.../T/greywall-XXXXXX`), which is
already covered by the existing `getTmpdirParent()` write rule. The path is:
- added explicitly to the Seatbelt `allow file-write*` rules
- set as `TMPDIR=...` in the sandboxed process environment
- cleaned up via `os.RemoveAll` in `Manager.Cleanup()`

The old static `/tmp/greywall` paths are removed from `GetDefaultWritePaths()`.

**Claude Code glob allowlist** (`profiles/agents/claude.go`)

Added glob patterns to the `claude`/`claude-code` profile's darwin allowlist:
```
/tmp/claude-*       → covers /tmp/claude-{pid}-cwd (working-dir tracker)
/tmp/claude-*/**    → covers contents of /tmp/claude-{uid}/ (session dir)
```
`expandMacOSTmpPaths` in `macos.go` automatically mirrors these to
`/private/tmp/claude-*` and `/private/tmp/claude-*/**`, so both the canonical
path and the symlink target are covered.

## Testing

- All existing unit and integration tests pass (`make test`)
- `TestMacOS_SeatbeltAllowsTmpGreywall` replaced with
  `TestMacOS_SeatbeltAllowsPerSessionTmpDir` (tests `$TMPDIR` write via the
  actual sandbox, not a static path)
- Manually verified with `greywall --profile claude -- claude --dangerously-skip-permissions`:
  bash tool calls (`echo hello`) now complete cleanly with no permission errors