### PR TITLE
fix: allow terminal ioctls under Landlock

### DIFF
--- a/internal/sandbox/linux_landlock.go
+++ b/internal/sandbox/linux_landlock.go
@@ -342,6 +342,12 @@ func (l *LandlockRuleset) AllowWrite(path string) error {
 		access |= LANDLOCK_ACCESS_FS_TRUNCATE
 	}
 
+	// Add IOCTL_DEV for ABI v5+ so interactive TUI programs can put
+	// terminals/PTYs into raw mode (TCGETS/TCSETS on /dev/tty, /dev/pts/*).
+	if l.abiVersion >= 5 {
+		access |= LANDLOCK_ACCESS_FS_IOCTL_DEV
+	}
+
 	return l.addPathRule(path, access)
 }
 


### PR DESCRIPTION
## Summary
- include `LANDLOCK_ACCESS_FS_IOCTL_DEV` in Landlock write permissions for ABI v5+
- allows interactive TUI apps to put `/dev/tty` and `/dev/pts/*` into raw mode
- should help unlock Greywall usage for OpenClaw and other interactive coding-agent users that rely on terminal raw mode

## Motivation
Interactive Node.js TUIs can fail under Greywall with `setRawMode EACCES` when Landlock handles `IOCTL_DEV` but the device path rule does not grant it. This was reproduced with the pi coding agent interactive mode; non-interactive commands worked, while `pi` failed entering raw mode.

This fix should start allowing OpenClaw-style interactive coding agent users to run safely inside Greywall instead of being limited to non-interactive commands.

## Testing
- `go test ./internal/sandbox`
- manual: rebuilt Greywall and verified `greywall -- pi --offline` works interactively
