### PR TITLE
feat: add NixOS support

### DIFF
--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -639,6 +639,16 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
+// resolveToolPath resolves only the directory component so multi-call binaries
+// (e.g. coreutils: sleep -> coreutils) still dispatch correctly via argv[0].
+func resolveToolPath(p string) string {
+	dir := filepath.Dir(p)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return filepath.Join(resolved, filepath.Base(p))
+	}
+	return p
+}
+
 // isDirectory returns true if the path exists and is a directory.
 func isDirectory(path string) bool {
 	info, err := os.Stat(path)
@@ -807,7 +817,8 @@ func buildDenyByDefaultMounts(cfg *config.Config, cwd string, dbusBridge *DbusBr
 	// /bin, /sbin, /lib, /lib64 are often symlinks to /usr/*. We must
 	// recreate these as symlinks via --symlink so the dynamic linker
 	// and shell can be found. Real directories get bind-mounted.
-	systemPaths := []string{"/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt"}
+	// /nix is included for NixOS where all binaries live under /nix/store.
+	systemPaths := []string{"/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt", "/nix"}
 	for _, p := range systemPaths {
 		if !fileExists(p) {
 			continue
@@ -1085,6 +1096,14 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	shellPath, err := exec.LookPath(shell)
 	if err != nil {
 		return "", fmt.Errorf("shell %q not found: %w", shell, err)
+	}
+	shellPath = resolveToolPath(shellPath)
+
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		sleepPath = "sleep" // fallback to PATH lookup inside sandbox
+	} else {
+		sleepPath = resolveToolPath(sleepPath)
 	}
 
 	cwd, _ := os.Getwd()
@@ -1542,7 +1561,7 @@ export no_proxy=localhost,127.0.0.1
 	}
 
 	// Add cleanup function
-	innerScript.WriteString(`
+	fmt.Fprintf(&innerScript, `
 # Cleanup function
 cleanup() {
     jobs -p | xargs -r kill 2>/dev/null
@@ -1550,10 +1569,10 @@ cleanup() {
 trap cleanup EXIT
 
 # Small delay to ensure services are ready
-sleep 0.3
+%s 0.3
 
 # Run the user command
-`)
+`, ShellQuoteSingle(sleepPath))
 
 	// In learning mode, wrap the command with strace to trace syscalls.
 	// Run strace in the foreground so the traced command retains terminal
@@ -1571,10 +1590,10 @@ GREYWALL_STRACE_EXIT=$?
 # Kill any orphaned child processes (LSP servers, file watchers, etc.)
 # that were spawned by the traced command and reparented to PID 1.
 kill -TERM -1 2>/dev/null
-sleep 0.1
+%s 0.1
 exit $GREYWALL_STRACE_EXIT
 `,
-			ShellQuoteSingle(opts.StraceLogPath), command,
+			ShellQuoteSingle(opts.StraceLogPath), command, ShellQuoteSingle(sleepPath),
 		)
 	case useLandlockWrapper:
 		// Use Landlock wrapper if available

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -209,11 +209,17 @@ func (f *LinuxFeatures) detectNetworkNamespace() {
 		return
 	}
 
-	// Run a minimal bwrap command with --unshare-net to test if it works
-	// We use a very short timeout since this should either succeed or fail immediately
-	// The bind mount is required in some environments
-	cmd := exec.Command("bwrap", "--unshare-net", "--ro-bind", "/", "/", "--", "/bin/true")
-	err := cmd.Run()
+	// Run a minimal bwrap command with --unshare-net to test if it works.
+	// Resolve true from PATH instead of hardcoding /bin/true: distributions like
+	// NixOS do not provide /bin/true, and a missing probe binary should not be
+	// mistaken for unavailable network namespaces.
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		return
+	}
+
+	cmd := exec.Command("bwrap", "--unshare-net", "--ro-bind", "/", "/", "--", truePath)
+	err = cmd.Run()
 	f.CanUnshareNet = err == nil
 }
 

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -218,7 +218,7 @@ func (f *LinuxFeatures) detectNetworkNamespace() {
 		return
 	}
 
-	cmd := exec.Command("bwrap", "--unshare-net", "--ro-bind", "/", "/", "--", truePath)
+	cmd := exec.Command("bwrap", "--unshare-net", "--ro-bind", "/", "/", "--", truePath) //nolint:gosec
 	err = cmd.Run()
 	f.CanUnshareNet = err == nil
 }

--- a/internal/sandbox/linux_landlock.go
+++ b/internal/sandbox/linux_landlock.go
@@ -60,6 +60,7 @@ func ApplyLandlockFromConfig(cfg *config.Config, cwd string, socketPaths []strin
 		"/var/lib",
 		"/var/cache",
 		"/opt",
+		"/nix", // NixOS: all binaries and libraries live under /nix/store
 	}
 
 	for _, p := range systemReadPaths {

--- a/internal/sandbox/sanitize.go
+++ b/internal/sandbox/sanitize.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -45,7 +46,44 @@ var DangerousEnvVars = []string{
 // agent writes a .so/.dylib and then uses LD_PRELOAD/DYLD_INSERT_LIBRARIES
 // in a subsequent command.
 func GetHardenedEnv() []string {
-	return FilterDangerousEnv(os.Environ())
+	env := FilterDangerousEnv(os.Environ())
+	if runtime.GOOS == "linux" {
+		env = resolvePathInEnv(env)
+	}
+	return env
+}
+
+// resolvePathInEnv rewrites the PATH entry in env so that each directory is
+// resolved to its real path via symlink evaluation. This is needed on NixOS
+// where PATH contains /run/current-system/sw/bin (a symlink chain into
+// /nix/store) which is unavailable inside the bwrap sandbox because /run is
+// replaced with a tmpfs.
+func resolvePathInEnv(env []string) []string {
+	result := make([]string, len(env))
+	for i, entry := range env {
+		if !strings.HasPrefix(entry, "PATH=") {
+			result[i] = entry
+			continue
+		}
+		value := entry[len("PATH="):]
+		dirs := strings.Split(value, string(filepath.ListSeparator))
+		seen := make(map[string]bool, len(dirs))
+		resolved := make([]string, 0, len(dirs))
+		for _, d := range dirs {
+			if d == "" {
+				continue
+			}
+			if r, err := filepath.EvalSymlinks(d); err == nil {
+				d = r
+			}
+			if !seen[d] {
+				seen[d] = true
+				resolved = append(resolved, d)
+			}
+		}
+		result[i] = "PATH=" + strings.Join(resolved, string(filepath.ListSeparator))
+	}
+	return result
 }
 
 // FilterDangerousEnv filters out dangerous environment variables from the given slice.


### PR DESCRIPTION
## Problem

On NixOS, executables live under `/nix/store` and `PATH` entries such as `/run/current-system/sw/bin` are symlink chains into the store. Inside the bwrap sandbox, `/run` is replaced with a tmpfs, so those symlinks become dangling — tools cannot be found and the sandbox fails.

Additionally, the network namespace probe hardcoded `/bin/true` which does not exist on NixOS, causing `greywall check` to falsely report `✗ network isolation`.

Fixes #81. Related to #22.

## Changes

- **`linux_features.go`**: resolve `true` from `PATH` instead of hardcoding `/bin/true` so the network namespace probe works on NixOS and any distro without `/bin/true`.
- **`linux.go`**: mount `/nix` read-only (like `/usr`, `/opt`); resolve shell and `sleep` paths through `resolveToolPath` so the directory component points into `/nix/store` rather than the hidden `/run/current-system/sw/bin`.
- **`linux_landlock.go`**: add `/nix` to Landlock read-allowed paths.
- **`sanitize.go`**: rewrite `PATH` entries through symlinks before passing them into the sandbox, so the sandbox `PATH` is consistent with what is actually mounted.

## Tests

On NixOS:

```sh
$ cat /etc/os-release |grep PRETTY
PRETTY_NAME="NixOS 25.11 (Xantusia)"
```

### Before

```sh
$ greywall --linux-features
Linux Sandbox Features:
  Kernel: 6.6
  Bubblewrap (bwrap): true
  Socat: true
  Network namespace (--unshare-net): false
  Seccomp: true (log level: 2)
  Landlock: true (ABI v3)
  eBPF: false (CAP_BPF: false, root: false)
  ip (iproute2): true
  /dev/net/tun: true
  tun2socks: true (embedded)

Feature Status:
  ✓ Minimum requirements met (bwrap + socat)
  ⚠ Network namespace unavailable (containerized environment?)
    Sandbox will still work but with reduced network isolation.
    This is common in Docker, GitHub Actions, and other CI systems.
  ○ Transparent proxy not available (needs ip, /dev/net/tun, network namespace)
  ✓ Landlock available for enhanced filesystem control
  ✓ Violation monitoring available
  ○ eBPF monitoring not available (needs CAP_BPF or root)
  
$  greywall -- claude -p '1+1'
bwrap: execvp /nix/store/lfbzxs5wyqd2122mpbj5azkxhxspw9cd-bash-interactive-5.3p3/bin/bash: No such file or directory
  ```

### After

```sh
$ greywall --linux-features
Linux Sandbox Features:
  Kernel: 6.6
  Bubblewrap (bwrap): true
  Socat: true
  Network namespace (--unshare-net): true
  Seccomp: true (log level: 2)
  Landlock: true (ABI v3)
  eBPF: false (CAP_BPF: false, root: false)
  ip (iproute2): true
  /dev/net/tun: true
  tun2socks: true (embedded)

Feature Status:
  ✓ Minimum requirements met (bwrap + socat)
  ✓ Network namespace isolation available
  ✓ Transparent proxy available (tun2socks + TUN device)
  ✓ Landlock available for enhanced filesystem control
  ✓ Violation monitoring available
  ○ eBPF monitoring not available (needs CAP_BPF or root)
  
  $ greywall -- claude -p '1+1'
2
```