### PR TITLE
feat(watch): --watch observability mode and greywatch alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /greywall
 /greywall_*
 /greywall-*
+/greywatch
+/greywatch_*
 
 # Tar archives
 *.tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,11 +101,14 @@ homebrew_casks:
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/greywall"]
           end
+          # greywatch is the same binary; argv[0] dispatch enables observe-only mode.
+          File.symlink("greywall", "#{staged_path}/greywatch") unless File.exist?("#{staged_path}/greywatch")
     dependencies:
       - cask: greyproxy
     caveats: |
       greyproxy is installed as a dependency and runs automatically.
       Dashboard: http://localhost:43080
+      Use "greywatch <cmd>" for observability-only mode (no profile, all network allowed).
 
 release:
   draft: false

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ download-tun2socks:
 build: download-tun2socks
 	@echo "Building $(BINARY_NAME)..."
 	$(GOBUILD) -o $(BINARY_NAME) -v ./cmd/greywall
+	@ln -sf $(BINARY_NAME) greywatch
 
 build-ci: download-tun2socks
 	@echo "CI: Building $(BINARY_NAME) with version info..."
@@ -41,6 +42,7 @@ build-ci: download-tun2socks
 	$(eval BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ'))
 	$(eval GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown"))
 	$(GOBUILD) -ldflags "-s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME) -X main.gitCommit=$(GIT_COMMIT)" -o $(BINARY_NAME) -v ./cmd/greywall
+	@ln -sf $(BINARY_NAME) greywatch
 
 test:
 	@echo "Running tests..."
@@ -54,6 +56,7 @@ clean:
 	@echo "Cleaning..."
 	$(GOCLEAN)
 	rm -f $(BINARY_NAME)
+	rm -f greywatch
 	rm -f $(BINARY_UNIX)
 	rm -f coverage.out
 	rm -f $(TUN2SOCKS_BIN_DIR)/tun2socks-linux-*
@@ -66,10 +69,12 @@ deps:
 build-linux: download-tun2socks
 	@echo "Building for Linux..."
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_UNIX) -v ./cmd/greywall
+	@ln -sf $(BINARY_UNIX) greywatch_unix
 
 build-darwin:
 	@echo "Building for macOS..."
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) -o $(BINARY_NAME)_darwin -v ./cmd/greywall
+	@ln -sf $(BINARY_NAME)_darwin greywatch_darwin
 
 install-lint-tools:
 	@echo "Installing linting tools..."

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 [![Release](https://img.shields.io/github/v/release/GreyhavenHQ/greywall)](https://github.com/GreyhavenHQ/greywall/releases)
 [![Product Hunt](https://img.shields.io/badge/Product%20Hunt-Greywall-orange?logo=producthunt)](https://www.producthunt.com/products/greywall?launch=greywall)
 
-Greywall is a container-free, deny-by-default sandbox for AI agents on Linux and macOS. It restricts filesystem access, network connections, and system calls to only what you explicitly allow, so tools like Claude Code, Cursor, Codex, and other AI coding agents can't access your SSH keys, environment secrets, or anything outside the working directory.
+Greywall is a container-free sandbox for AI coding agents on Linux and macOS, with two complementary modes:
 
-Use `--learning` to trace what a command needs and auto-generate a least-privilege config profile. All network traffic is transparently redirected through [greyproxy](https://github.com/GreyhavenHQ/greyproxy), a deny-by-default transparent proxy with a live allow/deny dashboard.
+- **`greywall` — deny-by-default sandbox.** Restricts filesystem access, network connections, and system calls to only what you explicitly allow, so tools like Claude Code, Cursor, Codex, and other AI agents can't reach your SSH keys, secrets, or anything outside the working directory.
+- **`greywatch` — allow-by-default observability layer** (equivalent to `greywall --watch`). Skips profile loading, registers a `*/*` allow rule with greyproxy so every network request is accepted but logged on the dashboard, and runs with a permissive filesystem. Use it to see what a tool actually does before deciding what to lock down.
+
+Both modes route every network connection through [greyproxy](https://github.com/GreyhavenHQ/greyproxy) — a transparent proxy with a live allow/deny dashboard — so traffic stays visible whether you're enforcing or observing. Use `--learning` to trace what a command needs and auto-generate a least-privilege config profile.
 
 *Supports Linux and macOS. See [platform support](https://docs.greywall.io/greywall/platform-support) for details.*
 
@@ -21,6 +24,7 @@ https://github.com/user-attachments/assets/7d62d45d-a201-4f24-9138-b460e4c157a8
 - **Command blocking** — dangerous commands like `rm -rf /` and `git push --force` are denied
 - **Built-in agent profiles** — one-command setup for Claude Code, Cursor, Codex, Aider, Goose, Gemini, OpenCode, Amp, Cline, Copilot, and more
 - **Learning mode** — traces filesystem access and auto-generates least-privilege profiles
+- **Observability mode** — `greywatch` (or `greywall --watch`) runs commands with no profile and all network allowed, so the greyproxy dashboard shows exactly what an agent does without anything being denied
 - **Five security layers on Linux** — Bubblewrap namespaces, Landlock, Seccomp BPF, eBPF monitoring, TUN-based network capture
 - **No containers required** — kernel-enforced sandboxing without Docker overhead
 
@@ -30,6 +34,9 @@ greywall -- curl https://example.com
 
 # Sandbox an AI coding agent with a built-in profile
 greywall -- claude
+
+# Observe what an agent does without blocking anything (allow-by-default)
+greywatch -- claude
 
 # Learn what filesystem access a command needs, then auto-generate a profile
 greywall --learning -- opencode
@@ -55,6 +62,8 @@ This also installs [greyproxy](https://github.com/GreyhavenHQ/greyproxy) as a de
 curl -fsSL https://raw.githubusercontent.com/GreyhavenHQ/greywall/main/install.sh | sh
 ```
 
+Both `greywall` and the `greywatch` alias (observability mode) are installed by Homebrew, `install.sh`, and `make build`. `greywatch` is a symlink to the same binary — argv[0] dispatch enables `--watch` automatically.
+
 <details>
 <summary>Other installation methods</summary>
 
@@ -62,6 +71,8 @@ curl -fsSL https://raw.githubusercontent.com/GreyhavenHQ/greywall/main/install.s
 
 ```bash
 go install github.com/GreyhavenHQ/greywall/cmd/greywall@latest
+# Create the greywatch alias yourself (Go install ships a single binary):
+ln -s "$(go env GOPATH)/bin/greywall" "$(go env GOPATH)/bin/greywatch"
 ```
 
 **[mise](https://mise.jdx.dev/):**
@@ -71,12 +82,18 @@ mise use -g github:GreyhavenHQ/greywall
 mise use -g github:GreyhavenHQ/greyproxy
 ```
 
+**Manual tarball:** GitHub release tarballs contain only the `greywall` binary. After extracting, create the alias yourself:
+
+```bash
+ln -s greywall greywatch
+```
+
 **Build from source:**
 
 ```bash
 git clone https://github.com/GreyhavenHQ/greywall
 cd greywall
-make setup && make build
+make setup && make build   # creates ./greywall and ./greywatch symlink
 ```
 
 </details>
@@ -177,6 +194,33 @@ greywall profiles show opencode
 # Next run auto-loads the learned profile
 greywall -- opencode
 ```
+
+### Watch mode (observability)
+
+Watch mode flips the policy: no profile is loaded, every network request is accepted but logged on the greyproxy dashboard, and the local filesystem is permissive. Use it to *see* what a tool does before deciding what to restrict — the inverse of deny-by-default.
+
+```bash
+# Same thing, two entry points
+greywatch -- claude
+greywall --watch -- claude
+
+# Inspect what claude touches in the greyproxy dashboard:
+#   http://localhost:43080
+```
+
+What stays the same:
+
+- **Network traffic still goes through greyproxy.** On Linux, `--unshare-net` + tun2socks force it; on macOS, the Seatbelt profile blocks direct egress to anything except the proxy. The dashboard sees every request.
+- **Hard safety floor remains.** Mandatory denies (`~/.ssh/authorized_keys`, git hooks, etc.) still apply even with the permissive filesystem.
+- **Credential substitution stays on** by default (disable with `--no-credential-protection`).
+
+What changes vs. normal mode:
+
+- No profile is loaded — observability runs from a blank default config.
+- A single `*/*` allow rule is registered with greyproxy for the session, so nothing is denied.
+- Filesystem deny-by-default is off and the command deny list is disabled.
+
+`-m` (violation monitor) stays orthogonal — combine `--watch -m` if you want both.
 
 ### Configuration
 

--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -55,6 +56,7 @@ var (
 	skipVersionCheck       bool
 	allowDests             []string
 	blankProfile           bool
+	watch                  bool
 )
 
 func main() {
@@ -63,6 +65,12 @@ func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "--landlock-apply" {
 		runLandlockWrapper()
 		return
+	}
+
+	// When invoked as "greywatch", inject --watch as the first flag so users get
+	// observability-mode behaviour without needing to remember the flag.
+	if len(os.Args) > 0 && filepath.Base(os.Args[0]) == "greywatch" {
+		os.Args = append([]string{os.Args[0], "--watch"}, os.Args[1:]...)
 	}
 
 	rootCmd := &cobra.Command{
@@ -139,6 +147,7 @@ Configuration file format:
 	_ = rootCmd.Flags().MarkHidden("skip-version-check")
 	rootCmd.Flags().StringArrayVar(&allowDests, "allow", nil, "Allow a network destination for this session (e.g. --allow api.example.com:443)")
 	rootCmd.Flags().BoolVar(&blankProfile, "blank", false, "With --learning, skip default profile network rules (start from scratch)")
+	rootCmd.Flags().BoolVar(&watch, "watch", false, "Watch mode: skip profile loading, allow all network (logged on dashboard), permissive filesystem — observability only, no deny-by-default")
 
 	// Hidden aliases for backwards compatibility
 	rootCmd.Flags().StringVar(&profileName, "template", "", "Alias for --profile (deprecated)")
@@ -243,9 +252,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// Extract command name for profile lookup
 	cmdName := extractCommandName(args, cmdString)
 
-	// Load profiles. In learning mode with --blank, skip profile loading entirely.
+	// Load profiles. Watch mode never loads profiles — observability runs from a
+	// blank default config so no per-tool rules influence what's observed.
+	// In learning mode with --blank, skip profile loading entirely.
 	// In learning mode without --blank, load profiles for network rules only.
-	if !learning || !blankProfile {
+	if !watch && (!learning || !blankProfile) {
 		if profileName != "" {
 			// Explicit --profile flag: resolve each comma-separated name
 			names := strings.Split(profileName, ",")
@@ -379,6 +390,24 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		cfg.Network.ForwardPorts = append(cfg.Network.ForwardPorts, fwdPorts...)
 	}
 
+	// Watch mode overrides: relax local enforcement so greywall acts as an
+	// observability layer instead of a deny-by-default sandbox. Network is
+	// permitted via a session-scoped */* allow rule registered with greyproxy
+	// (see sessionNetworkRules below), so all traffic stays visible on the
+	// dashboard while reaching its destination.
+	if watch {
+		falseVal := false
+		cfg.Filesystem.DefaultDenyRead = &falseVal
+		cfg.Filesystem.DenyRead = nil
+		cfg.Filesystem.DenyWrite = nil
+		if !slices.Contains(cfg.Filesystem.AllowWrite, "/") {
+			cfg.Filesystem.AllowWrite = append(cfg.Filesystem.AllowWrite, "/")
+		}
+		cfg.Command.UseDefaults = &falseVal
+		cfg.Command.Deny = nil
+		fmt.Fprintf(os.Stderr, "[greywall] Watch mode: no profile, all network allowed (logged on dashboard), permissive filesystem\n")
+	}
+
 	// Learning mode setup
 	if learning {
 		if err := sandbox.CheckLearningAvailable(); err != nil {
@@ -393,6 +422,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	if learning {
 		manager.SetLearning(true)
 		manager.SetCommandName(cmdName)
+	}
+	if watch {
+		manager.SetWatch(true)
 	}
 	defer manager.Cleanup()
 
@@ -477,6 +509,18 @@ func runCommand(cmd *cobra.Command, args []string) error {
 			PortPattern:        port,
 			Action:             "allow",
 			Notes:              "CLI --allow flag",
+		})
+	}
+
+	// Watch mode: register a single match-all allow rule on greyproxy so the
+	// dashboard logs every request without blocking anything. Greyproxy's
+	// pattern matcher treats "*" as match-all for both destination and port.
+	if watch {
+		sessionNetworkRules = append(sessionNetworkRules, sandbox.NetworkRuleInput{
+			DestinationPattern: "*",
+			PortPattern:        "*",
+			Action:             "allow",
+			Notes:              "greywatch: observe-only",
 		})
 	}
 
@@ -616,8 +660,12 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// If we have network rules or allow_all but didn't register a session yet
-	// (e.g., learning mode, or no credentials detected), register a session now.
-	if credSessionID == "" && (len(sessionNetworkRules) > 0 || learning) {
+	// (e.g., learning/watch mode, or no credentials detected), register a
+	// session now. The credential block above may have generated a sessionID
+	// without registering it (when no credentials were detected), so we gate
+	// on credSubstitutionActive — which is the source of truth for whether
+	// registration actually happened.
+	if !credSubstitutionActive && (len(sessionNetworkRules) > 0 || learning) {
 		sessionID, err := sandbox.GenerateSessionID()
 		if err == nil {
 			credSessionID = sessionID

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,13 @@ mkdir -p "$INSTALL_DIR"
 mv "$TMP/$BINARY" "$INSTALL_DIR/"
 chmod +x "$INSTALL_DIR/$BINARY"
 
-echo "Installed greywall $VERSION to $INSTALL_DIR"
+# Install the greywatch alias (same binary, dispatched via argv[0]).
+# Running "greywatch <cmd>" is equivalent to "greywall --watch -- <cmd>":
+# no profile, all network allowed and logged on the dashboard, permissive
+# filesystem — pure observability instead of deny-by-default.
+ln -sf "$BINARY" "$INSTALL_DIR/greywatch"
+
+echo "Installed greywall $VERSION to $INSTALL_DIR (with greywatch alias)"
 
 # Always install/update greyproxy
 echo ""

--- a/internal/profiles/agents/claude.go
+++ b/internal/profiles/agents/claude.go
@@ -31,7 +31,8 @@ func init() {
 				"~/.mcp.json",
 			}
 			if runtime.GOOS == "darwin" {
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"~/Library/Application Support/Claude/claude_desktop_config.json",
 					"/Library/Application Support/ClaudeCode/managed-settings.json",
 					"/Library/Application Support/ClaudeCode/managed-mcp.json",

--- a/internal/profiles/agents/codex.go
+++ b/internal/profiles/agents/codex.go
@@ -13,7 +13,8 @@ func init() {
 		Overlay: func() *config.Config {
 			allowRead := []string{"~/.codex", "~/.cache/codex"}
 			if runtime.GOOS == "darwin" {
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"~/Library/Preferences/com.openai.codex.plist",
 					"/Library/Preferences/com.openai.codex.plist",
 					"/Library/Managed Preferences/com.openai.codex.plist",

--- a/internal/profiles/agents/cursor.go
+++ b/internal/profiles/agents/cursor.go
@@ -14,11 +14,13 @@ func init() {
 			allowRead := []string{"~/.cursor", "~/.config/cursor", "~/.local/share/cursor-agent"}
 			allowWrite := []string{"~/.cursor", "~/.config/cursor", "~/.cache/cursor-compile-cache", "~/.local/share/cursor-agent"}
 			if runtime.GOOS == "darwin" {
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"~/Library/Application Support/Cursor",
 					"/Applications/Cursor.app",
 				)
-				allowWrite = append(allowWrite,
+				allowWrite = append(
+					allowWrite,
 					"~/Library/Caches/cursor-compile-cache",
 				)
 			}

--- a/internal/profiles/agents/gemini.go
+++ b/internal/profiles/agents/gemini.go
@@ -13,7 +13,8 @@ func init() {
 		Overlay: func() *config.Config {
 			allowRead := []string{"~/.gemini", "~/.cache/gemini"}
 			if runtime.GOOS == "darwin" {
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"/Library/Application Support/GeminiCli",
 				)
 			}

--- a/internal/profiles/agents/kilo.go
+++ b/internal/profiles/agents/kilo.go
@@ -14,7 +14,8 @@ func init() {
 			allowRead := []string{"~/.kilocode", "~/.roo", "~/.config/kilo", "~/.cache/kilo", "~/.local/share/kilo", "~/.local/state/kilo"}
 			allowWrite := []string{"~/.kilocode", "~/.roo", "~/.config/kilo", "~/.cache/kilo", "~/.local/share/kilo", "~/.local/state/kilo"}
 			if runtime.GOOS == "darwin" {
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"/Library/Application Support/RooCode",
 				)
 				vsCodeKilo := "~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code"

--- a/internal/profiles/base.go
+++ b/internal/profiles/base.go
@@ -46,7 +46,8 @@ func BaseProfile() *config.Config {
 	}
 
 	if runtime.GOOS == "darwin" {
-		allowRead = append(allowRead,
+		allowRead = append(
+			allowRead,
 			// macOS keychain (credential storage equivalent to secret-tool/pass on Linux)
 			"~/Library/Keychains",
 			"/Library/Keychains/System.keychain",
@@ -54,7 +55,8 @@ func BaseProfile() *config.Config {
 			"~/.CFUserTextEncoding",
 			"~/Library/Preferences/.GlobalPreferences.plist",
 		)
-		allowWrite = append(allowWrite,
+		allowWrite = append(
+			allowWrite,
 			"~/Library/Keychains",
 		)
 	}

--- a/internal/profiles/toolchains/containers.go
+++ b/internal/profiles/toolchains/containers.go
@@ -16,12 +16,14 @@ func init() {
 			allowWrite := []string{"~/.docker", "~/.config/containers", "~/.kube", "~/.config/helm", "~/.cache/helm"}
 			if runtime.GOOS == "darwin" {
 				// macOS Docker alternatives: OrbStack, Colima, Rancher Desktop
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"~/.orbstack",
 					"~/.colima",
 					"~/.rd",
 				)
-				allowWrite = append(allowWrite,
+				allowWrite = append(
+					allowWrite,
 					"~/.orbstack",
 					"~/.colima",
 					"~/.rd",

--- a/internal/profiles/toolchains/java.go
+++ b/internal/profiles/toolchains/java.go
@@ -14,7 +14,8 @@ func init() {
 		Overlay: func() *config.Config {
 			allowRead := []string{"~/.m2", "~/.gradle", "~/.java", "~/.sdkman", "~/.config/jgit"}
 			if runtime.GOOS == "darwin" {
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"/Library/Java/JavaVirtualMachines",
 				)
 			}

--- a/internal/profiles/toolchains/node.go
+++ b/internal/profiles/toolchains/node.go
@@ -34,11 +34,13 @@ func init() {
 			}
 			if runtime.GOOS == "darwin" {
 				// Playwright and Cypress store browser binaries in ~/Library/Caches on macOS
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"~/Library/Caches/ms-playwright",
 					"~/Library/Caches/Cypress",
 				)
-				allowWrite = append(allowWrite,
+				allowWrite = append(
+					allowWrite,
 					"~/Library/Caches/ms-playwright",
 					"~/Library/Caches/Cypress",
 				)

--- a/internal/profiles/toolchains/ruby.go
+++ b/internal/profiles/toolchains/ruby.go
@@ -15,7 +15,8 @@ func init() {
 			allowRead := []string{"~/.gem", "~/.bundle", "~/.rbenv", "~/.rvm", "~/.config/gem"}
 			if runtime.GOOS == "darwin" {
 				// macOS ships a system Ruby under /Library/Ruby
-				allowRead = append(allowRead,
+				allowRead = append(
+					allowRead,
 					"/Library/Ruby",
 				)
 			}

--- a/internal/sandbox/dangerous.go
+++ b/internal/sandbox/dangerous.go
@@ -75,7 +75,8 @@ func GetDefaultWritePaths() []string {
 	}
 
 	if home != "" {
-		paths = append(paths,
+		paths = append(
+			paths,
 			filepath.Join(home, ".npm/_logs"),
 			filepath.Join(home, ".greywall/debug"),
 		)
@@ -143,7 +144,8 @@ func GetDefaultReadablePaths() []string {
 	// read access to their full directories (not just bin/) to function properly.
 	// Runtimes load libraries, modules, and configs from within these directories.
 	if home != "" {
-		paths = append(paths,
+		paths = append(
+			paths,
 			// macOS user preferences and keychain (needed for TLS certificate verification)
 			filepath.Join(home, "Library/Preferences"),
 			filepath.Join(home, "Library/Keychains"),

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -662,7 +662,8 @@ func TestLinux_ForwardBridgeConnectsToHost(t *testing.T) {
 	cfg.Network.ForwardPorts = []int{19999}
 
 	// Start a listener on port 19999 that responds with "FORWARD_OK"
-	listener := exec.Command("socat", //nolint:gosec
+	listener := exec.Command(
+		"socat", //nolint:gosec
 		"TCP-LISTEN:19999,fork,reuseaddr",
 		`EXEC:'echo HTTP/1.0 200 OK\r\n\r\nFORWARD_OK'`,
 	)

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -1294,7 +1294,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	var dnsRelayResolvConf string // temp file path for custom resolv.conf
 	var caCertPath string         // greyproxy CA cert path (if available)
 	if proxyBridge != nil {
-		bwrapArgs = append(bwrapArgs,
+		bwrapArgs = append(
+			bwrapArgs,
 			"--bind", proxyBridge.SocketPath, proxyBridge.SocketPath,
 		)
 
@@ -1320,7 +1321,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 
 		// Bind DNS bridge socket if available
 		if dnsBridge != nil {
-			bwrapArgs = append(bwrapArgs,
+			bwrapArgs = append(
+				bwrapArgs,
 				"--bind", dnsBridge.SocketPath, dnsBridge.SocketPath,
 			)
 		}
@@ -1501,7 +1503,8 @@ export no_proxy=localhost,127.0.0.1
 		for i, port := range reverseBridge.Ports {
 			socketPath := reverseBridge.SocketPaths[i]
 			// Listen on Unix socket, forward to localhost:port inside the sandbox
-			fmt.Fprintf(&innerScript,
+			fmt.Fprintf(
+				&innerScript,
 				"socat UNIX-LISTEN:%s,fork,reuseaddr TCP:127.0.0.1:%d >/dev/null 2>&1 &\n",
 				socketPath, port,
 			)
@@ -1516,7 +1519,8 @@ export no_proxy=localhost,127.0.0.1
 		for i, port := range forwardBridge.Ports {
 			socketPath := forwardBridge.SocketPaths[i]
 			// Listen on localhost:port inside the sandbox, forward to Unix socket -> host localhost:port
-			fmt.Fprintf(&innerScript,
+			fmt.Fprintf(
+				&innerScript,
 				"socat TCP-LISTEN:%d,fork,reuseaddr,bind=127.0.0.1 UNIX-CONNECT:%s >/dev/null 2>&1 &\n",
 				port, socketPath,
 			)
@@ -1548,7 +1552,8 @@ sleep 0.3
 	// the common case of background daemons (LSP servers, watchers).
 	switch {
 	case opts.Learning && opts.StraceLogPath != "":
-		fmt.Fprintf(&innerScript, `# Learning mode: trace filesystem access (foreground for terminal access)
+		fmt.Fprintf(
+			&innerScript, `# Learning mode: trace filesystem access (foreground for terminal access)
 strace -f -qq -I2 -e trace=openat,open,creat,mkdir,mkdirat,unlinkat,renameat,renameat2,symlinkat,linkat -o %s -- %s
 GREYWALL_STRACE_EXIT=$?
 # Kill any orphaned child processes (LSP servers, file watchers, etc.)

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -124,6 +124,10 @@ type LinuxSandboxOptions struct {
 	Debug bool
 	// Learning mode: permissive sandbox with strace tracing
 	Learning bool
+	// Watch mode: permissive sandbox for pure observability. Shares the
+	// permissive bind layout with Learning but does not bind a strace log or
+	// wrap the command with strace.
+	Watch bool
 	// Path to host-side strace log file (bind-mounted into sandbox)
 	StraceLogPath string
 	// RewrittenEnvFiles maps original .env file paths to temp files containing
@@ -1088,10 +1092,16 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		}
 	}
 
-	// Learning mode: permissive sandbox with home + cwd writable
-	if opts.Learning {
+	// Learning and watch modes share a permissive sandbox layout: root bound
+	// read-only, home + cwd writable, D-Bus isolated for safety. Learning
+	// additionally binds a strace log later; watch does not.
+	if opts.Learning || opts.Watch {
 		if opts.Debug {
-			fmt.Fprintf(os.Stderr, "[greywall:linux] Learning mode: binding root read-only, home + cwd writable\n")
+			modeName := "Learning"
+			if opts.Watch {
+				modeName = "Watch"
+			}
+			fmt.Fprintf(os.Stderr, "[greywall:linux] %s mode: binding root read-only, home + cwd writable\n", modeName)
 		}
 		// Bind entire root read-only as baseline
 		bwrapArgs = append(bwrapArgs, "--ro-bind", "/", "/")
@@ -1105,9 +1115,9 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 			bwrapArgs = append(bwrapArgs, "--bind", cwd, cwd)
 		}
 
-		// Block D-Bus session bus even in learning mode to prevent sandbox escape
-		// via GVFS/gnome-keyring. dconf and Wayland still work since they use
-		// their own sockets, not the D-Bus session bus.
+		// Block D-Bus session bus even in permissive modes to prevent sandbox
+		// escape via GVFS/gnome-keyring. dconf and Wayland still work since
+		// they use their own sockets, not the D-Bus session bus.
 		bwrapArgs = append(bwrapArgs, dbusIsolationArgs(dbusBridge, opts.AllowAudio, opts.Debug)...)
 
 	}
@@ -1115,8 +1125,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	defaultDenyRead := cfg != nil && cfg.Filesystem.IsDefaultDenyRead()
 
 	switch {
-	case opts.Learning:
-		// Skip defaultDenyRead logic in learning mode (already set up above)
+	case opts.Learning || opts.Watch:
+		// Skip defaultDenyRead logic in permissive modes (already set up above)
 	case defaultDenyRead:
 		// Deny-by-default mode: start with empty root, then whitelist system paths + CWD
 		if opts.Debug {
@@ -1157,9 +1167,9 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		}
 	}
 
-	// In learning mode, skip writable paths, deny rules, and mandatory deny
-	// (the sandbox is already permissive with home + cwd writable)
-	if !opts.Learning {
+	// In learning/watch modes, skip writable paths, deny rules, and mandatory
+	// deny (the sandbox is already permissive with home + cwd writable).
+	if !opts.Learning && !opts.Watch {
 
 		writablePaths := make(map[string]bool)
 
@@ -1278,7 +1288,7 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 			}
 		}
 
-	} // end if !opts.Learning
+	} // end if !opts.Learning && !opts.Watch
 
 	// Bind the proxy bridge Unix socket into the sandbox (needs to be writable)
 	var dnsRelayResolvConf string // temp file path for custom resolv.conf
@@ -1602,6 +1612,9 @@ exit $GREYWALL_STRACE_EXIT
 		}
 		if opts.Learning {
 			featureList = append(featureList, "learning(strace)")
+		}
+		if opts.Watch {
+			featureList = append(featureList, "watch(observe-only)")
 		}
 		fmt.Fprintf(os.Stderr, "[greywall:linux] Sandbox: %s\n", strings.Join(featureList, ", "))
 	}

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -359,7 +359,8 @@ func PrintDependencyStatus() []string {
 
 		if !features.CanUnshareNet && features.HasBwrap {
 			if val := readSysctl("kernel/apparmor_restrict_unprivileged_userns"); val == "1" {
-				steps = append(steps,
+				steps = append(
+					steps,
 					"sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0",
 					"echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/99-greywall-userns.conf",
 				)

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -62,6 +62,7 @@ type LinuxSandboxOptions struct {
 	Monitor           bool
 	Debug             bool
 	Learning          bool
+	Watch             bool
 	StraceLogPath     string
 	RewrittenEnvFiles map[string]string
 	AllowAudio        bool

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -168,7 +168,8 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 
 		// Allow reading data from essential system paths
 		for _, systemPath := range GetDefaultReadablePaths() {
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(allow file-read-data",
 				fmt.Sprintf("  (subpath %s))", escapePath(systemPath)),
 			)
@@ -176,14 +177,16 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 
 		// Allow reading CWD (full recursive read access)
 		if cwd != "" {
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(allow file-read-data",
 				fmt.Sprintf("  (subpath %s))", escapePath(cwd)),
 			)
 
 			// Allow ancestor directory traversal (literal only, so programs can resolve CWD path)
 			for _, ancestor := range getAncestorDirectories(cwd) {
-				rules = append(rules,
+				rules = append(
+					rules,
 					fmt.Sprintf("(allow file-read-data (literal %s))", escapePath(ancestor)),
 				)
 			}
@@ -196,7 +199,8 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 			shellConfigs := []string{".bashrc", ".bash_profile", ".profile", ".zshrc", ".zprofile", ".zshenv", ".inputrc"}
 			for _, f := range shellConfigs {
 				p := filepath.Join(home, f)
-				rules = append(rules,
+				rules = append(
+					rules,
 					fmt.Sprintf("(allow file-read-data (literal %s))", escapePath(p)),
 				)
 			}
@@ -205,7 +209,8 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 			homeCaches := []string{".cache", ".npm", ".cargo", ".rustup", ".local", ".config", ".nvm", ".pyenv", ".rbenv", ".asdf"}
 			for _, d := range homeCaches {
 				p := filepath.Join(home, d)
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(allow file-read-data",
 					fmt.Sprintf("  (subpath %s))", escapePath(p)),
 				)
@@ -218,12 +223,14 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 
 			if ContainsGlobChars(normalized) {
 				regex := GlobToRegex(normalized)
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(allow file-read-data",
 					fmt.Sprintf("  (regex %s))", escapePath(regex)),
 				)
 			} else {
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(allow file-read-data",
 					fmt.Sprintf("  (subpath %s))", escapePath(normalized)),
 				)
@@ -243,7 +250,8 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 				if _, ok := rewrittenEnvFiles[p]; ok {
 					continue // credential substitution active; allow read
 				}
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(deny file-read-data",
 					fmt.Sprintf("  (literal %s)", escapePath(p)),
 					fmt.Sprintf("  (with message %q))", logTag),
@@ -253,7 +261,8 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 			// Only add the .env.* regex deny if not all files are handled by
 			// credential substitution.
 			if deniedFiles > 0 {
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(deny file-read-data",
 					fmt.Sprintf("  (regex %s)", escapePath("^"+regexp.QuoteMeta(cwd)+"/\\.env\\..*$")),
 					fmt.Sprintf("  (with message %q))", logTag),
@@ -267,7 +276,8 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 
 	// Deny sensitive system files (greyproxy encryption key, CA private key)
 	for _, p := range GetSensitiveSystemPaths() {
-		rules = append(rules,
+		rules = append(
+			rules,
 			"(deny file-read-data",
 			fmt.Sprintf("  (literal %s)", escapePath(p)),
 			fmt.Sprintf("  (with message %q))", logTag),
@@ -282,13 +292,15 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(deny file-read-data",
 				fmt.Sprintf("  (regex %s)", escapePath(regex)),
 				fmt.Sprintf("  (with message %q))", logTag),
 			)
 		} else {
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(deny file-read-data",
 				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 				fmt.Sprintf("  (with message %q))", logTag),
@@ -309,7 +321,8 @@ func generateWriteRules(cwd string, allowPaths, denyPaths []string, allowGitConf
 
 	// Auto-allow CWD for writes (project directory should be writable)
 	if cwd != "" {
-		rules = append(rules,
+		rules = append(
+			rules,
 			"(allow file-write*",
 			fmt.Sprintf("  (subpath %s)", escapePath(cwd)),
 			fmt.Sprintf("  (with message %q))", logTag),
@@ -319,7 +332,8 @@ func generateWriteRules(cwd string, allowPaths, denyPaths []string, allowGitConf
 	// Allow TMPDIR parent on macOS
 	for _, tmpdirParent := range getTmpdirParent() {
 		normalized := NormalizePath(tmpdirParent)
-		rules = append(rules,
+		rules = append(
+			rules,
 			"(allow file-write*",
 			fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 			fmt.Sprintf("  (with message %q))", logTag),
@@ -332,13 +346,15 @@ func generateWriteRules(cwd string, allowPaths, denyPaths []string, allowGitConf
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(allow file-write*",
 				fmt.Sprintf("  (regex %s)", escapePath(regex)),
 				fmt.Sprintf("  (with message %q))", logTag),
 			)
 		} else {
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(allow file-write*",
 				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 				fmt.Sprintf("  (with message %q))", logTag),
@@ -361,13 +377,15 @@ func generateWriteRules(cwd string, allowPaths, denyPaths []string, allowGitConf
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(deny file-write*",
 				fmt.Sprintf("  (regex %s)", escapePath(regex)),
 				fmt.Sprintf("  (with message %q))", logTag),
 			)
 		} else {
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(deny file-write*",
 				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 				fmt.Sprintf("  (with message %q))", logTag),
@@ -390,7 +408,8 @@ func generateMoveBlockingRules(pathPatterns []string, logTag string) []string {
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(deny file-write-unlink",
 				fmt.Sprintf("  (regex %s)", escapePath(regex)),
 				fmt.Sprintf("  (with message %q))", logTag),
@@ -406,14 +425,16 @@ func generateMoveBlockingRules(pathPatterns []string, logTag string) []string {
 					baseDir = filepath.Dir(staticPrefix)
 				}
 
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(deny file-write-unlink",
 					fmt.Sprintf("  (literal %s)", escapePath(baseDir)),
 					fmt.Sprintf("  (with message %q))", logTag),
 				)
 
 				for _, ancestor := range getAncestorDirectories(baseDir) {
-					rules = append(rules,
+					rules = append(
+						rules,
 						"(deny file-write-unlink",
 						fmt.Sprintf("  (literal %s)", escapePath(ancestor)),
 						fmt.Sprintf("  (with message %q))", logTag),
@@ -421,14 +442,16 @@ func generateMoveBlockingRules(pathPatterns []string, logTag string) []string {
 				}
 			}
 		} else {
-			rules = append(rules,
+			rules = append(
+				rules,
 				"(deny file-write-unlink",
 				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 				fmt.Sprintf("  (with message %q))", logTag),
 			)
 
 			for _, ancestor := range getAncestorDirectories(normalized) {
-				rules = append(rules,
+				rules = append(
+					rules,
 					"(deny file-write-unlink",
 					fmt.Sprintf("  (literal %s)", escapePath(ancestor)),
 					fmt.Sprintf("  (with message %q))", logTag),

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -24,6 +24,7 @@ type Manager struct {
 	monitor       bool
 	initialized   bool
 	learning      bool   // learning mode: permissive sandbox with strace/eslogger
+	watch         bool   // watch mode: permissive sandbox for pure observability (no strace, no profile gen)
 	straceLogPath string // host-side temp file for strace output (Linux)
 	commandName   string // name of the command being learned
 	// macOS learning mode fields
@@ -60,6 +61,16 @@ func (m *Manager) SetCommandName(name string) {
 // IsLearning returns whether learning mode is enabled.
 func (m *Manager) IsLearning() bool {
 	return m.learning
+}
+
+// SetWatch enables or disables watch (observability) mode.
+func (m *Manager) SetWatch(enabled bool) {
+	m.watch = enabled
+}
+
+// IsWatch returns whether watch mode is enabled.
+func (m *Manager) IsWatch() bool {
+	return m.watch
 }
 
 // SetRewrittenEnvFiles sets the map of .env files rewritten with credential placeholders.
@@ -249,16 +260,21 @@ func (m *Manager) WrapCommand(command string) (string, error) {
 			// In learning mode, run command directly (no sandbox-exec wrapping)
 			return command, nil
 		}
+		// Watch mode goes through the normal macOS path so the sandbox-exec
+		// wrapper still exports proxy env vars (HTTP_PROXY, ALL_PROXY, ...).
+		// The permissive overrides applied in main.go ensure the generated
+		// Seatbelt profile is wide-open for filesystem reads.
 		return WrapCommandMacOS(m.config, command, m.exposedPorts, m.rewrittenEnvFiles, m.debug)
 	case platform.Linux:
 		if m.learning {
 			return m.wrapCommandLearning(command)
 		}
 		return WrapCommandLinuxWithOptions(m.config, command, m.proxyBridge, m.dnsBridge, m.reverseBridge, m.forwardBridge, m.dbusBridge, m.tun2socksPath, LinuxSandboxOptions{
-			UseLandlock:       true,
-			UseSeccomp:        true,
-			UseEBPF:           true,
+			UseLandlock:       !m.watch,
+			UseSeccomp:        !m.watch,
+			UseEBPF:           !m.watch,
 			Debug:             m.debug,
+			Watch:             m.watch,
 			RewrittenEnvFiles: m.rewrittenEnvFiles,
 			AllowAudio:        m.config != nil && m.config.AllowAudio,
 		})

--- a/internal/sandbox/monitor.go
+++ b/internal/sandbox/monitor.go
@@ -44,7 +44,8 @@ func (m *LogMonitor) Start() error {
 	// Build predicate to filter for this session's violations only
 	predicate := fmt.Sprintf(`eventMessage ENDSWITH "%s"`, m.sessionSuffix)
 
-	m.cmd = exec.CommandContext(ctx, "log", "stream", //nolint:gosec // predicate is constructed from trusted session suffix
+	m.cmd = exec.CommandContext( //nolint:gosec // predicate is constructed from trusted session suffix
+		ctx, "log", "stream",
 		"--predicate", predicate,
 		"--style", "compact",
 	)

--- a/internal/sandbox/utils.go
+++ b/internal/sandbox/utils.go
@@ -74,7 +74,8 @@ func GenerateProxyEnvVars(proxyURL, httpProxyURL string) []string {
 		"192.168.0.0/16",
 	}, ",")
 
-	envVars = append(envVars,
+	envVars = append(
+		envVars,
 		"NO_PROXY="+noProxy,
 		"no_proxy="+noProxy,
 	)
@@ -82,7 +83,8 @@ func GenerateProxyEnvVars(proxyURL, httpProxyURL string) []string {
 	// ALL_PROXY uses socks5h:// (remote DNS resolution via proxy)
 	if proxyURL != "" {
 		socksURL := strings.Replace(proxyURL, "socks5://", "socks5h://", 1)
-		envVars = append(envVars,
+		envVars = append(
+			envVars,
 			"ALL_PROXY="+socksURL,
 			"all_proxy="+socksURL,
 		)
@@ -90,7 +92,8 @@ func GenerateProxyEnvVars(proxyURL, httpProxyURL string) []string {
 
 	// HTTP_PROXY/HTTPS_PROXY use the HTTP CONNECT proxy (not SOCKS5)
 	if httpProxyURL != "" {
-		envVars = append(envVars,
+		envVars = append(
+			envVars,
 			"HTTP_PROXY="+httpProxyURL,
 			"HTTPS_PROXY="+httpProxyURL,
 			"http_proxy="+httpProxyURL,


### PR DESCRIPTION
## Summary

Adds a `--watch` flag that turns greywall into an **observability layer** instead of a deny-by-default sandbox, plus a `greywatch` alias that auto-applies it.

In `--watch` mode:
- **No profile loading** (skipped entirely — starts from blank default config).
- **All network requests allowed** by registering a single `*/*` `allow` rule with greyproxy per session. Every request is logged on the dashboard but reaches its destination. Greyproxy's pattern matcher already treats `*` as match-all for both destination and port, so no greyproxy changes are needed.
- **Permissive filesystem and command policy**: deny-by-default reads off, no command deny list. The hard-coded mandatory denies (`.ssh/authorized_keys`, git hooks, etc.) are preserved as a safety floor.
- **Network containment is unchanged**: `--unshare-net` + tun2socks on Linux and Seatbelt `(deny default)` + proxy allow on macOS still force every connection through greyproxy.
- **No `-m` implied** — combine `--watch -m` if you want violation monitoring on top.
- **`--blank` untouched**.
- Credential substitution stays on by default (disable with `--no-credential-protection`).

## `greywatch` alias

Same binary, dispatched via `argv[0]`. Running `greywatch <cmd>` is equivalent to `greywall --watch -- <cmd>`. The symlink is created by:
- `Makefile` (`build`, `build-linux`, `build-darwin`)
- `install.sh` (after binary extraction)
- Homebrew cask post-install hook

Manual tarball users can create the symlink themselves: `ln -s greywall greywatch`.

## Drive-by bug fix

The existing fallback session-registration was gated on `credSessionID == ""`, but the credential block always pre-generates a session id even when no credentials are detected — so any session that needed network rules but had no credentials silently never registered. Now gated on `credSubstitutionActive`, the source of truth for whether registration actually happened. Without this fix, `--watch` (and `--learning --blank` in some setups) wouldn't push their rules to greyproxy.

## Test plan

- [x] `make build` produces both `greywall` and `greywatch` (symlink)
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] `./greywall --watch -- echo hello` prints watch-mode banner and runs
- [x] `./greywatch -- echo hello` (via symlink) dispatches identically
- [x] `./greywall --watch -d -- echo test` confirms session registration is attempted against greyproxy (HTTP error when greyproxy is not running, as expected)
- [x] `./greywall --help` lists the `--watch` flag with a clear description
- [x] End-to-end with a running greyproxy: verify the `*/*` allow rule appears in the dashboard and all traffic is logged but not denied
- [ ] Linux smoke test inside bwrap: verify `--unshare-net` is still applied and tun2socks routes traffic through greyproxy