### PR TITLE
fix(brew): expose greywatch alias in PATH via cask binary target

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,14 +95,17 @@ homebrew_casks:
     license: "Apache-2.0"
     binaries:
       - greywall
+    # Alias greywatch -> greywall. argv[0] dispatch in the binary enables
+    # observe-only mode automatically. Injected via custom_block because
+    # goreleaser's binaries: list does not support the `target:` option.
+    custom_block: |
+      binary "greywall", target: "greywatch"
     hooks:
       post:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/greywall"]
           end
-          # greywatch is the same binary; argv[0] dispatch enables observe-only mode.
-          File.symlink("greywall", "#{staged_path}/greywatch") unless File.exist?("#{staged_path}/greywatch")
     dependencies:
       - cask: greyproxy
     caveats: |


### PR DESCRIPTION
## Summary

- `brew install --cask greywall` was supposed to install both `greywall` and the `greywatch` alias, but `greywatch` was missing from `$PATH`. The `hooks.post.install` block created a symlink inside `staged_path` (`/opt/homebrew/Caskroom/greywall/<ver>/greywatch`), which Homebrew never links into `${HOMEBREW_PREFIX}/bin` — only `binary` stanzas get exposed there.
- Replace the dead `File.symlink` with a `custom_block` that injects `binary "greywall", target: "greywatch"`. Brew now creates and tracks the alias symlink (cleaned up on uninstall). `custom_block` is needed because goreleaser's `binaries:` list does not support the `target:` option (verified against the upstream `HomebrewCask` struct and `cask.rb` template).
- Non-brew install paths were already correct: `install.sh` creates `$INSTALL_DIR/greywatch`, `make build` creates a local symlink, and the README documents the manual `ln -s` step for `go install` users.

## Test plan

- [ ] Next release: confirm the generated cask in `GreyhavenHQ/homebrew-tap` contains both `binary "greywall"` and `binary "greywall", target: "greywatch"`.
- [ ] After release: `brew install --cask greywall` on a clean Mac, verify `which greywatch` resolves to `${HOMEBREW_PREFIX}/bin/greywatch` and `greywatch --help` shows observability mode.
- [ ] `brew uninstall --cask greywall` removes both `greywall` and `greywatch` symlinks.