### PR TITLE
fix(cli): keep --allow / profile network rules working under --proxy-user

### DIFF
--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -359,13 +359,14 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	//   2. cmdName               (auto-detected from the wrapped command)
 	//   3. "proxy"               (fallback, required by gost for auth)
 	// This always overrides any existing credentials in the URL.
-	proxyUser := "proxy"
-	switch {
-	case proxyUserFlag != "":
-		proxyUser = proxyUserFlag
-	case cmdName != "":
-		proxyUser = cmdName
-	}
+	//
+	// The same value is reused as the greyproxy session container name (see the
+	// RegisterSession calls below). greyproxy associates a live proxy connection
+	// with its session — and therefore enforces that session's network rules,
+	// including --allow — by matching the SOCKS5 login against the container
+	// name. The two MUST stay identical or session-scoped rules silently stop
+	// applying (notably whenever --proxy-user is set).
+	proxyUser := proxyIdentity(proxyUserFlag, cmdName)
 	for _, proxyField := range []*string{&cfg.Network.ProxyURL, &cfg.Network.HTTPProxyURL} {
 		if *proxyField != "" {
 			if u, err := url.Parse(*proxyField); err == nil {
@@ -555,10 +556,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 				detected = []sandbox.CredentialMapping{}
 			}
 
-			containerName := cmdName
-			if containerName == "" {
-				containerName = "sandbox"
-			}
+			// Must match the SOCKS5 login (proxyUser) so greyproxy maps this
+			// session's network rules onto the sandbox's proxy connection.
+			containerName := proxyUser
 
 			if len(detected) > 0 || len(injectLabels) > 0 {
 				// Build the set of credential key names for .env file scanning.
@@ -669,10 +669,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		sessionID, err := sandbox.GenerateSessionID()
 		if err == nil {
 			credSessionID = sessionID
-			containerName := cmdName
-			if containerName == "" {
-				containerName = "sandbox"
-			}
+			// Must match the SOCKS5 login (proxyUser) so greyproxy maps this
+			// session's network rules onto the sandbox's proxy connection.
+			containerName := proxyUser
 			cwd, _ := os.Getwd()
 			meta := &sandbox.SessionMetadata{
 				WorkDir: cwd,
@@ -901,6 +900,27 @@ func resolveProfile(name string, debug bool) (*config.Config, error) {
 	}
 
 	return nil, fmt.Errorf("profile %q not found (no saved profile and no built-in profile)\nRun: greywall profiles list", name)
+}
+
+// proxyIdentity returns the identity used both as the SOCKS5 login injected
+// into the proxy URL and as the greyproxy session container name. greyproxy
+// matches a live connection to its session — and thus enforces that session's
+// network rules, including --allow — by this login, so the two callers MUST
+// derive their value from here to keep them identical.
+//
+// Precedence (highest wins):
+//  1. proxyUserFlag (explicit --proxy-user override)
+//  2. cmdName       (auto-detected from the wrapped command)
+//  3. "proxy"       (fallback, required by gost for auth)
+func proxyIdentity(proxyUserFlag, cmdName string) string {
+	switch {
+	case proxyUserFlag != "":
+		return proxyUserFlag
+	case cmdName != "":
+		return cmdName
+	default:
+		return "proxy"
+	}
 }
 
 // extractCommandName extracts a human-readable command name from the arguments.

--- a/cmd/greywall/main_test.go
+++ b/cmd/greywall/main_test.go
@@ -1,0 +1,34 @@
+// Package main implements the greywall CLI.
+package main
+
+import "testing"
+
+// TestProxyIdentity is the regression test for #96. The greyproxy session
+// container name and the SOCKS5 login are both derived from proxyIdentity, so
+// they can never diverge. Before the fix, the container name was derived
+// independently as `cmdName || "sandbox"` and ignored --proxy-user, so a run
+// with --proxy-user registered its --allow / profile rules under a container
+// name that no live connection ever logged in as, and the rules were silently
+// dropped. The "flag overrides command name" case below pins the behavior the
+// old container-name derivation got wrong (it would have returned "curl").
+func TestProxyIdentity(t *testing.T) {
+	tests := []struct {
+		name          string
+		proxyUserFlag string
+		cmdName       string
+		want          string
+	}{
+		{"flag overrides command name", "agent1", "curl", "agent1"},
+		{"flag overrides empty command", "agent1", "", "agent1"},
+		{"command name when no flag", "", "curl", "curl"},
+		{"fallback when both empty", "", "", "proxy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := proxyIdentity(tt.proxyUserFlag, tt.cmdName); got != tt.want {
+				t.Errorf("proxyIdentity(%q, %q) = %q, want %q",
+					tt.proxyUserFlag, tt.cmdName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #96.

## Problem

greyproxy associates a live proxy connection with its session — and therefore enforces that session's network rules, including `--allow` and profile `network.rules` — by matching the **SOCKS5 login** against the session **`container_name`** (`docs/templates.md:88,100`; the `--proxy-user` help at `main.go:132` calls this "match per-client rules by login"). The random `sessionID` is never sent over the proxy connection, so the login is the only identifier tying the connection to its rules.

These two values were derived independently in `runCommand`:

| value | old derivation |
|---|---|
| SOCKS5 login (`proxyUser`) | `proxyUserFlag` ?? `cmdName` ?? `"proxy"` |
| session `container_name` | `cmdName` ?? `"sandbox"` |

They matched for an ordinary `greywall -- curl …` run, but diverged when:

- **`--proxy-user X`** was set (login `X`, container `cmdName`) — the flag added in #87, *after* the session-rules feature #80, so this regressed silently;
- **`cmdName` was empty** (login `"proxy"`, container `"sandbox"`).

In those cases the `--allow`/profile rules were registered under a container name that no live connection ever authenticated as, so greyproxy never applied them and the traffic was blocked despite the explicit allow.

## Fix

Introduce a single `proxyIdentity(proxyUserFlag, cmdName)` helper and derive both the proxy-URL login and the `RegisterSession` `container_name` from it, so they can never diverge.

## Test

`TestProxyIdentity` (`cmd/greywall/main_test.go`) pins the precedence; the `--proxy-user` case (`proxyIdentity("agent1","curl") == "agent1"`) is the regression guard — the old container-name derivation would have produced `"curl"`.

## Verification

- `go test ./cmd/greywall/` ✅
- `make lint` → 0 issues ✅
- `go build ./...` ✅
