### PR TITLE
fix(macos): honor -f/--forward port forwarding

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -24,7 +24,7 @@ greywall <subcommand> [args...]
 | `--http-proxy <url>` | | Override the HTTP CONNECT proxy URL (default: `http://localhost:43051`) |
 | `--dns <addr>` | | Override the host-side DNS server address (default: `localhost:43053`) |
 | `--port <port>` | `-p` | Expose a port for inbound connections into the sandbox (repeatable) |
-| `--forward <port>` | `-f` | Forward a host `localhost` port into the sandbox (Linux only, repeatable) |
+| `--forward <port>` | `-f` | Forward a host `localhost` port into the sandbox (Linux and macOS, repeatable) |
 | `--command <cmd>` | `-c` | Run a shell command string (supports `&&`, `;`, pipes) |
 | `--debug` | `-d` | Verbose output: proxy activity, filter decisions, sandbox command |
 | `--monitor` | `-m` | Show only violations and blocked requests (audit mode) |
@@ -60,9 +60,9 @@ greywall -p 3000 -c "npm run dev"
 greywall -p 3000 -p 8080 -c "make start"
 ```
 
-### `-f / --forward` (Linux only)
+### `-f / --forward`
 
-Forward a host `localhost` port *into* the sandbox so the sandboxed process can reach a host service (database, cache, and so on). This is the Linux equivalent of `allowLocalOutbound` on macOS, which only works there because the macOS sandbox shares the host network stack.
+Forward a host `localhost` port *into* the sandbox so the sandboxed process can reach a host service (database, cache, and so on). Works on both platforms: on Linux it sets up a socat bridge through the isolated network namespace; on macOS it adds a targeted Seatbelt allow rule for just those ports (a narrower alternative to `allowLocalOutbound`, which opens *all* host localhost ports).
 
 ```bash
 # Reach a host Postgres from inside the sandbox

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -28,7 +28,7 @@ Because filtering lives in the proxy, domain allowlists, rule changes, and live 
 - `allowLocalBinding`: lets a sandboxed process *listen* on local ports (e.g., dev servers).
 - `allowLocalOutbound`: lets a sandboxed process connect to host `localhost` services (macOS only; see below).
 - `-p/--port`: exposes inbound ports so things outside the sandbox can reach your server.
-- `-f/--forward`: forwards a host localhost port *into* the sandbox (Linux only).
+- `-f/--forward`: forwards a host localhost port *into* the sandbox.
 - `forwardPorts`: config-file equivalent of `-f` for specifying ports to forward.
 
 These are separate on purpose. A typical safe default for dev servers is:
@@ -38,13 +38,13 @@ These are separate on purpose. A typical safe default for dev servers is:
 
 ### Port forwarding: platform differences
 
-On macOS, the sandbox shares the host network stack, so `allowLocalOutbound: true` is enough for the sandboxed process to reach any host localhost service.
+On macOS, the sandbox shares the host network stack, so `allowLocalOutbound: true` lets the sandboxed process reach *any* host localhost service. To reach only *specific* host ports, use `-f <port>` (or `forwardPorts`), which adds a targeted Seatbelt allow rule for just those ports.
 
-On Linux, the sandbox runs in an isolated network namespace (bubblewrap `--unshare-net`). The host's `localhost` is not reachable from inside the sandbox. To connect to a specific host service, you must explicitly forward its port with `-f` (or `forwardPorts` in the config file).
+On Linux, the sandbox runs in an isolated network namespace (bubblewrap `--unshare-net`). The host's `localhost` is not reachable from inside the sandbox. To connect to a specific host service, you must explicitly forward its port with `-f` (or `forwardPorts` in the config file), which sets up a socat bridge.
 
 | Feature | macOS | Linux |
 |---------|-------|-------|
-| Sandbox connects to host `localhost` | `allowLocalOutbound: true` | `-f <port>` or `forwardPorts: [port]` |
+| Sandbox connects to host `localhost` | `allowLocalOutbound: true` (all ports) or `-f <port>` (specific ports) | `-f <port>` or `forwardPorts: [port]` |
 | Host connects to sandbox port | `-p <port>` | `-p <port>` |
 | Sandbox listens on local port | `allowLocalBinding: true` | `allowLocalBinding: true` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ Greywall routes all network traffic through an external SOCKS5 proxy. Domain fil
 | `allowAllUnixSockets` | Allow all Unix sockets |
 | `allowLocalBinding` | Allow binding to local ports |
 | `allowLocalOutbound` | Allow outbound connections to host `localhost`, e.g., local DBs. Defaults to `allowLocalBinding` if not set. **macOS only**; on Linux, use `forwardPorts` to reach specific host ports. |
-| `forwardPorts` | Host localhost ports to forward into the sandbox (Linux only; array of integers). Equivalent to repeated `-f/--forward` flags. |
+| `forwardPorts` | Host localhost ports to forward into the sandbox (array of integers). Equivalent to repeated `-f/--forward` flags. Works on Linux (socat bridge) and macOS (Seatbelt allow rule). |
 | `httpProxyUrl` | HTTP CONNECT proxy URL (default: `http://localhost:43051`) |
 
 ## Filesystem Configuration

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -41,6 +41,7 @@ type MacOSSandboxParams struct {
 	AllowAllUnixSockets     bool
 	AllowLocalBinding       bool
 	AllowLocalOutbound      bool
+	ForwardPorts            []int // Host localhost ports to allow outbound to (-f/--forward)
 	DefaultDenyRead         bool
 	Cwd                     string // Current working directory (for deny-by-default CWD allowlisting)
 	ReadAllowPaths          []string
@@ -636,6 +637,14 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 		if params.AllowLocalOutbound {
 			profile.WriteString(`(allow network-outbound (local ip "localhost:*"))
 `)
+		} else {
+			// Forwarded ports (-f/--forward): allow outbound to specific host
+			// localhost ports. On macOS the network is shared with the host (no
+			// namespace), so forwarding is just a targeted allow rule rather than
+			// the socat bridge used on Linux. Redundant if AllowLocalOutbound is set.
+			for _, port := range params.ForwardPorts {
+				fmt.Fprintf(&profile, "(allow network-outbound (remote ip \"localhost:%d\"))\n", port)
+			}
 		}
 
 		if params.AllowAllUnixSockets {
@@ -757,6 +766,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, exposedPorts []int, re
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
+		ForwardPorts:            cfg.Network.ForwardPorts,
 		DefaultDenyRead:         cfg.Filesystem.IsDefaultDenyRead(),
 		Cwd:                     cwd,
 		ReadAllowPaths:          cfg.Filesystem.AllowRead,
@@ -773,6 +783,9 @@ func WrapCommandMacOS(cfg *config.Config, command string, exposedPorts []int, re
 	}
 	if debug && allowLocalBinding && !allowLocalOutbound {
 		fmt.Fprintf(os.Stderr, "[greywall:macos] Blocking localhost outbound (AllowLocalOutbound=false)\n")
+	}
+	if debug && !allowLocalOutbound && len(cfg.Network.ForwardPorts) > 0 {
+		fmt.Fprintf(os.Stderr, "[greywall:macos] Forwarding host localhost ports: %v\n", cfg.Network.ForwardPorts)
 	}
 
 	profile := GenerateSandboxProfile(params)

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -172,6 +172,80 @@ func TestMacOS_ProfileNetworkSection(t *testing.T) {
 	}
 }
 
+// TestMacOS_ProfileForwardPorts verifies that -f/--forward ports produce
+// per-port localhost outbound allow rules in the Seatbelt profile, and that
+// they are omitted when localhost outbound is already broadly allowed.
+func TestMacOS_ProfileForwardPorts(t *testing.T) {
+	tests := []struct {
+		name               string
+		allowLocalOutbound bool
+		forwardPorts       []int
+		wantContains       []string
+		wantNotContain     []string
+	}{
+		{
+			name:         "single forwarded port",
+			forwardPorts: []int{42000},
+			wantContains: []string{
+				`(allow network-outbound (remote ip "localhost:42000"))`,
+			},
+			wantNotContain: []string{
+				`(allow network-outbound (local ip "localhost:*"))`,
+			},
+		},
+		{
+			name:         "multiple forwarded ports",
+			forwardPorts: []int{5432, 6379},
+			wantContains: []string{
+				`(allow network-outbound (remote ip "localhost:5432"))`,
+				`(allow network-outbound (remote ip "localhost:6379"))`,
+			},
+		},
+		{
+			name:               "broad localhost outbound supersedes per-port rules",
+			allowLocalOutbound: true,
+			forwardPorts:       []int{42000},
+			wantContains: []string{
+				`(allow network-outbound (local ip "localhost:*"))`,
+			},
+			wantNotContain: []string{
+				`(allow network-outbound (remote ip "localhost:42000"))`,
+			},
+		},
+		{
+			name:         "no forwarded ports, no per-port rules",
+			forwardPorts: nil,
+			wantNotContain: []string{
+				`(allow network-outbound (remote ip "localhost:`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := MacOSSandboxParams{
+				Command:                 "echo test",
+				NeedsNetworkRestriction: true,
+				AllowLocalOutbound:      tt.allowLocalOutbound,
+				ForwardPorts:            tt.forwardPorts,
+			}
+
+			profile := GenerateSandboxProfile(params)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(profile, want) {
+					t.Errorf("profile should contain %q, got:\n%s", want, profile)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(profile, notWant) {
+					t.Errorf("profile should NOT contain %q, got:\n%s", notWant, profile)
+				}
+			}
+		})
+	}
+}
+
 // TestMacOS_DefaultDenyRead verifies that the defaultDenyRead option properly restricts filesystem reads.
 func TestMacOS_DefaultDenyRead(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

On macOS, `-f/--forward` (and the `forwardPorts` config field) was **silently ignored**. A sandboxed process could not reach a forwarded host `localhost` port:

```bash
greywall -- curl localhost:42000          # blocked (expected — deny by default)
greywall -f 42000 -- curl localhost:42000 # ALSO blocked (the bug)
```

The forwarding logic (`NewForwardBridge`) lived entirely inside the Linux branch of `manager.go`, and `WrapCommandMacOS` never read `cfg.Network.ForwardPorts`.

## Fix

Linux needs a `socat` bridge because the sandbox runs in an isolated network namespace. macOS shares the host network stack, so forwarding just needs a Seatbelt allow rule. For each forwarded port we now emit:

```
(allow network-outbound (remote ip "localhost:<port>"))
```

skipped when `allowLocalOutbound` already opens all localhost ports. This is narrower than `allowLocalOutbound` (which opens *all* host localhost ports), preserving deny-by-default.

## Verification (real listener on macOS)

| Command | Result |
|---|---|
| `curl localhost:PORT` (no `-f`) | denied ✓ |
| `-f PORT -- curl localhost:PORT` | succeeds ✓ |
| `-f PORT` then curl a *different* port | denied ✓ (port-specific) |

- Adds `TestMacOS_ProfileForwardPorts`.
- Updates docs that incorrectly described forwarding as Linux-only.
- `make fmt && make lint` clean; sandbox/config/cmd tests pass.

Closes #98