### PR TITLE
feat(cli): --allow-path / --allow-read-path for per-session filesystem grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ greywall --proxy socks5://localhost:1080 -- npm install
 # Expose a port for inbound connections (e.g., dev servers)
 greywall -p 3000 -c "npm run dev"
 
+# Grant an extra directory/file for this run (read+write, or read-only)
+greywall --allow-path /tmp/work -- mytool
+greywall --allow-read-path /data/refs -- mytool
+
 # Enable debug logging
 greywall -d -- curl https://example.com
 
@@ -142,23 +146,6 @@ greywall check
 # Install and start greyproxy
 greywall setup
 ```
-
-### Grant extra filesystem access (per session)
-
-Greywall only allows the current directory by default. To open one extra directory or file for a single run — without writing a profile — use `--allow-path` (read+write) or `--allow-read-path` (read-only). Both are repeatable, accept a directory or a file, and persist nothing.
-
-```bash
-# Read+write scratch directory for this run
-greywall --allow-path /tmp/work -- mytool
-
-# Read-only reference data (writes to it stay blocked)
-greywall --allow-read-path /data/reference.csv -- mytool
-
-# Mix: read-only inputs, read+write output
-greywall --allow-read-path /data/refs --allow-path /tmp/out -- mytool
-```
-
-For a persistent grant, use `filesystem.allowRead` / `filesystem.allowWrite` in your [config](#configuration) instead.
 
 ### Agent profiles
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ greywall check
 greywall setup
 ```
 
+### Grant extra filesystem access (per session)
+
+Greywall only allows the current directory by default. To open one extra directory or file for a single run — without writing a profile — use `--allow-path` (read+write) or `--allow-read-path` (read-only). Both are repeatable, accept a directory or a file, and persist nothing.
+
+```bash
+# Read+write scratch directory for this run
+greywall --allow-path /tmp/work -- mytool
+
+# Read-only reference data (writes to it stay blocked)
+greywall --allow-read-path /data/reference.csv -- mytool
+
+# Mix: read-only inputs, read+write output
+greywall --allow-read-path /data/refs --allow-path /tmp/out -- mytool
+```
+
+For a persistent grant, use `filesystem.allowRead` / `filesystem.allowWrite` in your [config](#configuration) instead.
+
 ### Agent profiles
 
 Greywall ships with built-in sandbox profiles for popular AI coding agents (Claude Code, Codex, Cursor, Aider, Goose, Gemini CLI, OpenCode, Amp, Cline, Copilot, Kilo, Auggie, Droid) and toolchains (Node, Python, Go, Rust, Java, Ruby, Docker).

--- a/cmd/greywall/main.go
+++ b/cmd/greywall/main.go
@@ -55,6 +55,8 @@ var (
 	ignoreVars             []string
 	skipVersionCheck       bool
 	allowDests             []string
+	allowPaths             []string
+	allowReadPaths         []string
 	blankProfile           bool
 	watch                  bool
 )
@@ -99,6 +101,8 @@ Examples:
   greywall -p 3000 -c "npm run dev"                             # Expose port 3000
   greywall -f 5432 -- psql -h localhost                          # Forward host port into sandbox
   greywall --learning -- opencode                                # Learn filesystem needs
+  greywall --allow-path /tmp/work -- mytool      # Grant rw to an extra dir/file for this run
+  greywall --allow-read-path /data/refs -- mytool # Grant read-only to a dir/file for this run
   greywall --secret MY_VAR -- command            # Protect a custom env var
   greywall --inject ANTHROPIC_API_KEY -- command  # Inject from proxy dashboard
 
@@ -146,6 +150,8 @@ Configuration file format:
 	rootCmd.Flags().BoolVar(&skipVersionCheck, "skip-version-check", false, "Skip greyproxy version check (for testing)")
 	_ = rootCmd.Flags().MarkHidden("skip-version-check")
 	rootCmd.Flags().StringArrayVar(&allowDests, "allow", nil, "Allow a network destination for this session (e.g. --allow api.example.com:443)")
+	rootCmd.Flags().StringArrayVar(&allowPaths, "allow-path", nil, "Allow read+write access to a directory or file for this session (repeatable, e.g. --allow-path /tmp/work)")
+	rootCmd.Flags().StringArrayVar(&allowReadPaths, "allow-read-path", nil, "Allow read-only access to a directory or file for this session (repeatable, e.g. --allow-read-path /data/refs)")
 	rootCmd.Flags().BoolVar(&blankProfile, "blank", false, "With --learning, skip default profile network rules (start from scratch)")
 	rootCmd.Flags().BoolVar(&watch, "watch", false, "Watch mode: skip profile loading, allow all network (logged on dashboard), permissive filesystem — observability only, no deny-by-default")
 
@@ -406,6 +412,16 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		cfg.Command.UseDefaults = &falseVal
 		cfg.Command.Deny = nil
 		fmt.Fprintf(os.Stderr, "[greywall] Watch mode: no profile, all network allowed (logged on dashboard), permissive filesystem\n")
+	}
+
+	// Session-scoped filesystem grants from --allow-path / --allow-read-path.
+	// Applied after profile merge and watch overrides so they always take effect.
+	// Nothing is persisted; the sandbox resolves and binds these paths for this
+	// run only. Non-existent paths are tolerated (Linux skips them, macOS Seatbelt
+	// ignores them), matching the lenient behaviour of --allow.
+	applySessionAllowPaths(cfg, allowPaths, allowReadPaths)
+	if debug && (len(allowPaths) > 0 || len(allowReadPaths) > 0) {
+		fmt.Fprintf(os.Stderr, "[greywall] Session allow: %d rw, %d read-only path(s)\n", len(allowPaths), len(allowReadPaths))
 	}
 
 	// Learning mode setup
@@ -1405,6 +1421,21 @@ parseCommand:
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[greywall:landlock-wrapper] Exec failed: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// applySessionAllowPaths grants session-scoped filesystem access from the
+// --allow-path (read+write) and --allow-read-path (read-only) CLI flags.
+// Read-write paths are appended to both AllowRead and AllowWrite; read-only
+// paths are appended to AllowRead only. The underlying sandbox plumbing
+// (NormalizePath + per-platform binding) handles directories and files alike.
+func applySessionAllowPaths(cfg *config.Config, rwPaths, roPaths []string) {
+	if len(roPaths) > 0 {
+		cfg.Filesystem.AllowRead = append(cfg.Filesystem.AllowRead, roPaths...)
+	}
+	if len(rwPaths) > 0 {
+		cfg.Filesystem.AllowRead = append(cfg.Filesystem.AllowRead, rwPaths...)
+		cfg.Filesystem.AllowWrite = append(cfg.Filesystem.AllowWrite, rwPaths...)
 	}
 }
 

--- a/cmd/greywall/main_test.go
+++ b/cmd/greywall/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/GreyhavenHQ/greywall/internal/config"
+)
+
+// TestApplySessionAllowPaths verifies that --allow-path grants read+write while
+// --allow-read-path grants read-only, both appended to the session config.
+func TestApplySessionAllowPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		rwPaths   []string
+		roPaths   []string
+		baseRead  []string
+		baseWrite []string
+		wantRead  []string
+		wantWrite []string
+	}{
+		{
+			name:      "no flags leaves config untouched",
+			wantRead:  nil,
+			wantWrite: nil,
+		},
+		{
+			name:      "allow-path adds to both read and write",
+			rwPaths:   []string{"/tmp/work"},
+			wantRead:  []string{"/tmp/work"},
+			wantWrite: []string{"/tmp/work"},
+		},
+		{
+			name:      "allow-read-path adds to read only",
+			roPaths:   []string{"/data/refs"},
+			wantRead:  []string{"/data/refs"},
+			wantWrite: nil,
+		},
+		{
+			name:      "both flags combine: rw in both, ro in read only",
+			rwPaths:   []string{"/tmp/out"},
+			roPaths:   []string{"/data/refs", "/data/reference.csv"},
+			wantRead:  []string{"/data/refs", "/data/reference.csv", "/tmp/out"},
+			wantWrite: []string{"/tmp/out"},
+		},
+		{
+			name:      "appends to existing config paths",
+			rwPaths:   []string{"/tmp/work"},
+			baseRead:  []string{"/existing/read"},
+			baseWrite: []string{"/existing/write"},
+			wantRead:  []string{"/existing/read", "/tmp/work"},
+			wantWrite: []string{"/existing/write", "/tmp/work"},
+		},
+		{
+			name:      "multiple rw paths repeatable",
+			rwPaths:   []string{"/tmp/a", "/tmp/b"},
+			wantRead:  []string{"/tmp/a", "/tmp/b"},
+			wantWrite: []string{"/tmp/a", "/tmp/b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Filesystem: config.FilesystemConfig{
+					AllowRead:  tt.baseRead,
+					AllowWrite: tt.baseWrite,
+				},
+			}
+
+			applySessionAllowPaths(cfg, tt.rwPaths, tt.roPaths)
+
+			if !slices.Equal(cfg.Filesystem.AllowRead, tt.wantRead) {
+				t.Errorf("AllowRead = %v, want %v", cfg.Filesystem.AllowRead, tt.wantRead)
+			}
+			if !slices.Equal(cfg.Filesystem.AllowWrite, tt.wantWrite) {
+				t.Errorf("AllowWrite = %v, want %v", cfg.Filesystem.AllowWrite, tt.wantWrite)
+			}
+		})
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,6 +29,8 @@ greywall <subcommand> [args...]
 | `--debug` | `-d` | Verbose output: proxy activity, filter decisions, sandbox command |
 | `--monitor` | `-m` | Show only violations and blocked requests (audit mode) |
 | `--learning` | | Trace filesystem access with strace/eslogger and auto-generate a profile |
+| `--allow-path <path>` | | Grant read+write access to a directory **or** file for this session only (repeatable). Nothing is persisted. See [below](#--allow-path-and---allow-read-path). |
+| `--allow-read-path <path>` | | Grant read-only access to a directory **or** file for this session only (repeatable). Nothing is persisted. |
 | `--secret <VAR>` | | Treat an environment variable as a credential even if it doesn't match the auto-detection rules (repeatable). See [Credential Protection](./credential-protection). |
 | `--inject <LABEL>` | | Inject a credential stored in the greyproxy dashboard into the sandbox by label (repeatable) |
 | `--ignore-secret <VAR>` | | Exclude a variable from credential detection even if it matches the heuristics (repeatable) |
@@ -73,6 +75,31 @@ greywall -f 5432 -f 6379 -- make test
 ```
 
 See [Concepts](./concepts#port-forwarding-platform-differences) for the full explanation of the platform difference.
+
+### `--allow-path` and `--allow-read-path`
+
+Greywall is deny-by-default for the filesystem: a sandboxed command can only touch the current working directory (plus system paths). When you just need one extra directory or file for a single run — a scratch/temp dir, a sibling project, a reference dataset — these flags grant it **for that session only**. Nothing is written to disk and no profile is created or modified; for a persistent grant, use `filesystem.allowRead` / `filesystem.allowWrite` in your [config](./configuration).
+
+- `--allow-path` grants **read+write**.
+- `--allow-read-path` grants **read-only** (writes stay blocked).
+
+Both are repeatable and accept either a **directory or a file**. Paths may be absolute, relative (resolved against the CWD), or `~`-prefixed.
+
+```bash
+# Read+write scratch directory for this run
+greywall --allow-path /tmp/work -- mytool
+
+# Several extra paths at once
+greywall --allow-path /tmp/work --allow-path ~/.cache/foo -- mytool
+
+# Read-only reference data (a single file here); writes to it are denied
+greywall --allow-read-path /data/reference.csv -- mytool
+
+# Mix: read-only inputs, read+write output
+greywall --allow-read-path /data/refs --allow-path /tmp/out -- mytool
+```
+
+These compose with profiles — they are added on top of whatever a profile already allows.
 
 ## Subcommands
 

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -1006,6 +1006,49 @@ func buildDenyByDefaultMounts(cfg *config.Config, cwd string, dbusBridge *DbusBr
 	return args
 }
 
+// writableBindArgs returns bwrap --bind args that make the configured writable
+// paths actually writable, overriding the read-only root. It covers the default
+// system write paths plus cfg.Filesystem.AllowWrite (which includes the
+// read+write grants from --allow-path). These binds are appended after the
+// read-only binds from buildDenyByDefaultMounts, so for a path that is both
+// readable and writable the later --bind wins. Only existing paths are bound;
+// bwrap rejects a missing source.
+func writableBindArgs(cfg *config.Config) []string {
+	writablePaths := make(map[string]bool)
+
+	// Default write paths (system paths needed for operation).
+	for _, p := range GetDefaultWritePaths() {
+		// Skip /dev paths (handled by --dev) and /tmp paths (handled by --tmpfs).
+		if strings.HasPrefix(p, "/dev/") || strings.HasPrefix(p, "/tmp/") || strings.HasPrefix(p, "/private/tmp/") {
+			continue
+		}
+		writablePaths[p] = true
+	}
+
+	// User-specified allowWrite paths.
+	if cfg != nil && cfg.Filesystem.AllowWrite != nil {
+		for _, p := range ExpandGlobPatterns(cfg.Filesystem.AllowWrite) {
+			writablePaths[p] = true
+		}
+
+		// Non-glob paths, normalized.
+		for _, p := range cfg.Filesystem.AllowWrite {
+			normalized := NormalizePath(p)
+			if !ContainsGlobChars(normalized) {
+				writablePaths[normalized] = true
+			}
+		}
+	}
+
+	var args []string
+	for p := range writablePaths {
+		if fileExists(p) {
+			args = append(args, "--bind", p, p)
+		}
+	}
+	return args
+}
+
 // isSystemMountPoint returns true if the path is a top-level system directory
 // that gets mounted directly under --tmpfs / (bwrap auto-creates these).
 func isSystemMountPoint(path string) bool {
@@ -1171,39 +1214,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	// deny (the sandbox is already permissive with home + cwd writable).
 	if !opts.Learning && !opts.Watch {
 
-		writablePaths := make(map[string]bool)
-
-		// Add default write paths (system paths needed for operation)
-		for _, p := range GetDefaultWritePaths() {
-			// Skip /dev paths (handled by --dev) and /tmp paths (handled by --tmpfs)
-			if strings.HasPrefix(p, "/dev/") || strings.HasPrefix(p, "/tmp/") || strings.HasPrefix(p, "/private/tmp/") {
-				continue
-			}
-			writablePaths[p] = true
-		}
-
-		// Add user-specified allowWrite paths
-		if cfg != nil && cfg.Filesystem.AllowWrite != nil {
-			expandedPaths := ExpandGlobPatterns(cfg.Filesystem.AllowWrite)
-			for _, p := range expandedPaths {
-				writablePaths[p] = true
-			}
-
-			// Add non-glob paths
-			for _, p := range cfg.Filesystem.AllowWrite {
-				normalized := NormalizePath(p)
-				if !ContainsGlobChars(normalized) {
-					writablePaths[normalized] = true
-				}
-			}
-		}
-
 		// Make writable paths actually writable (override read-only root)
-		for p := range writablePaths {
-			if fileExists(p) {
-				bwrapArgs = append(bwrapArgs, "--bind", p, p)
-			}
-		}
+		bwrapArgs = append(bwrapArgs, writableBindArgs(cfg)...)
 
 		// Handle denyRead paths - hide them
 		// For directories: use --tmpfs to replace with empty tmpfs

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -366,6 +366,48 @@ func TestMacOS_DenyReadUserPaths(t *testing.T) {
 	}
 }
 
+// TestMacOS_SessionAllowPaths verifies the Seatbelt profile distinguishes
+// read+write grants (--allow-path) from read-only grants (--allow-read-path):
+// a read-write path gets both a read-data and a file-write* allow, while a
+// read-only path gets a read-data allow but NO file-write* allow. Covers both
+// a directory and a single file (the file case must not get a write rule).
+func TestMacOS_SessionAllowPaths(t *testing.T) {
+	rwDir := "/home/user/scratch"
+	roDir := "/home/user/reference"
+	roFile := "/home/user/reference.csv"
+
+	params := MacOSSandboxParams{
+		Command:         "echo test",
+		DefaultDenyRead: true,
+		Cwd:             "/home/user/project",
+		// --allow-path appends to both read and write; --allow-read-path to read only.
+		ReadAllowPaths:  []string{roDir, roFile, rwDir},
+		WriteAllowPaths: []string{rwDir},
+	}
+
+	profile := GenerateSandboxProfile(params)
+
+	// Read-write path: present as both a read allow and a write allow.
+	if !strings.Contains(profile, fmt.Sprintf(`(subpath %q)`, rwDir)) {
+		t.Errorf("rw path %q missing read allow\nProfile:\n%s", rwDir, profile)
+	}
+	wantWrite := fmt.Sprintf("(allow file-write*\n  (subpath %q)", rwDir)
+	if !strings.Contains(profile, wantWrite) {
+		t.Errorf("rw path %q missing file-write* allow\nExpected: %s\nProfile:\n%s", rwDir, wantWrite, profile)
+	}
+
+	// Read-only directory and file: read allow present, write allow absent.
+	for _, ro := range []string{roDir, roFile} {
+		if !strings.Contains(profile, fmt.Sprintf(`(subpath %q)`, ro)) {
+			t.Errorf("read-only path %q missing read allow\nProfile:\n%s", ro, profile)
+		}
+		unwantedWrite := fmt.Sprintf("(allow file-write*\n  (subpath %q)", ro)
+		if strings.Contains(profile, unwantedWrite) {
+			t.Errorf("read-only path %q must NOT have a file-write* allow\nProfile:\n%s", ro, profile)
+		}
+	}
+}
+
 // TestExpandMacOSTmpPaths verifies that /tmp and /private/tmp paths are properly mirrored.
 func TestExpandMacOSTmpPaths(t *testing.T) {
 	tests := []struct {

--- a/internal/sandbox/mounts_linux_test.go
+++ b/internal/sandbox/mounts_linux_test.go
@@ -22,20 +22,27 @@ func hasBindTriple(args []string, flag, src, dst string) bool {
 	return false
 }
 
-// TestLinux_SessionAllowPaths verifies that buildDenyByDefaultMounts binds
-// --allow-path entries writable (--bind) and --allow-read-path entries
-// read-only (--ro-bind, never --bind). Covers a directory and a single file
-// (the file exercises the !isDirectory branch).
+// TestLinux_SessionAllowPaths verifies the two-layer Linux binding for
+// --allow-path / --allow-read-path grants:
+//
+//   - buildDenyByDefaultMounts grants read access (--ro-bind) to every path in
+//     AllowRead, i.e. both --allow-path and --allow-read-path entries.
+//   - writableBindArgs adds a writable --bind only for AllowWrite entries, i.e.
+//     --allow-path. Appended after the read-only binds, the later --bind wins,
+//     so the path ends up writable. Read-only paths get no --bind.
+//
+// Covers a directory and a single file (the file exercises the !isDirectory
+// branch in the read-bind layer).
 func TestLinux_SessionAllowPaths(t *testing.T) {
 	tmp := t.TempDir()
 	rwDir := filepath.Join(tmp, "scratch")
 	roDir := filepath.Join(tmp, "reference")
 	roFile := filepath.Join(tmp, "reference.csv")
 
-	if err := os.MkdirAll(rwDir, 0o755); err != nil {
+	if err := os.MkdirAll(rwDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(roDir, 0o755); err != nil {
+	if err := os.MkdirAll(roDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(roFile, []byte("data"), 0o600); err != nil {
@@ -50,25 +57,27 @@ func TestLinux_SessionAllowPaths(t *testing.T) {
 	cfg.Filesystem.AllowRead = []string{roDir, roFile, rwDir}
 	cfg.Filesystem.AllowWrite = []string{rwDir}
 
-	args := buildDenyByDefaultMounts(cfg, cwd, nil, nil, false)
-
 	// Paths are normalized (symlinks resolved) before binding.
 	wantRW := NormalizePath(rwDir)
 	wantRODir := NormalizePath(roDir)
 	wantROFile := NormalizePath(roFile)
 
-	// Read-write dir must be bound writable.
-	if !hasBindTriple(args, "--bind", wantRW, wantRW) {
-		t.Errorf("rw path %q not bound writable (--bind)\nargs: %v", wantRW, args)
+	// Read layer: every granted path is bound read-only.
+	readArgs := buildDenyByDefaultMounts(cfg, cwd, nil, nil, false)
+	for _, ro := range []string{wantRW, wantRODir, wantROFile} {
+		if !hasBindTriple(readArgs, "--ro-bind", ro, ro) {
+			t.Errorf("granted path %q not bound readable (--ro-bind)\nargs: %v", ro, readArgs)
+		}
 	}
 
-	// Read-only dir and file: bound read-only, never writable.
+	// Write layer: only the read-write path is bound writable.
+	writeArgs := writableBindArgs(cfg)
+	if !hasBindTriple(writeArgs, "--bind", wantRW, wantRW) {
+		t.Errorf("rw path %q not bound writable (--bind)\nargs: %v", wantRW, writeArgs)
+	}
 	for _, ro := range []string{wantRODir, wantROFile} {
-		if !hasBindTriple(args, "--ro-bind", ro, ro) {
-			t.Errorf("read-only path %q not bound --ro-bind\nargs: %v", ro, args)
-		}
-		if hasBindTriple(args, "--bind", ro, ro) {
-			t.Errorf("read-only path %q must NOT be bound writable (--bind)\nargs: %v", ro, args)
+		if hasBindTriple(writeArgs, "--bind", ro, ro) {
+			t.Errorf("read-only path %q must NOT be bound writable (--bind)\nargs: %v", ro, writeArgs)
 		}
 	}
 }

--- a/internal/sandbox/mounts_linux_test.go
+++ b/internal/sandbox/mounts_linux_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GreyhavenHQ/greywall/internal/config"
+)
+
+// hasBindTriple reports whether args contains the consecutive sequence
+// [flag, src, dst] (bubblewrap emits bind mounts as three separate args).
+// Note "--bind" does not match "--ro-bind" since the tokens differ exactly.
+func hasBindTriple(args []string, flag, src, dst string) bool {
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == flag && args[i+1] == src && args[i+2] == dst {
+			return true
+		}
+	}
+	return false
+}
+
+// TestLinux_SessionAllowPaths verifies that buildDenyByDefaultMounts binds
+// --allow-path entries writable (--bind) and --allow-read-path entries
+// read-only (--ro-bind, never --bind). Covers a directory and a single file
+// (the file exercises the !isDirectory branch).
+func TestLinux_SessionAllowPaths(t *testing.T) {
+	tmp := t.TempDir()
+	rwDir := filepath.Join(tmp, "scratch")
+	roDir := filepath.Join(tmp, "reference")
+	roFile := filepath.Join(tmp, "reference.csv")
+
+	if err := os.MkdirAll(rwDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(roDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(roFile, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := t.TempDir()
+
+	cfg := config.Default()
+	// --allow-path appends to both AllowRead and AllowWrite; --allow-read-path
+	// to AllowRead only. Mirror that wiring here.
+	cfg.Filesystem.AllowRead = []string{roDir, roFile, rwDir}
+	cfg.Filesystem.AllowWrite = []string{rwDir}
+
+	args := buildDenyByDefaultMounts(cfg, cwd, nil, nil, false)
+
+	// Paths are normalized (symlinks resolved) before binding.
+	wantRW := NormalizePath(rwDir)
+	wantRODir := NormalizePath(roDir)
+	wantROFile := NormalizePath(roFile)
+
+	// Read-write dir must be bound writable.
+	if !hasBindTriple(args, "--bind", wantRW, wantRW) {
+		t.Errorf("rw path %q not bound writable (--bind)\nargs: %v", wantRW, args)
+	}
+
+	// Read-only dir and file: bound read-only, never writable.
+	for _, ro := range []string{wantRODir, wantROFile} {
+		if !hasBindTriple(args, "--ro-bind", ro, ro) {
+			t.Errorf("read-only path %q not bound --ro-bind\nargs: %v", ro, args)
+		}
+		if hasBindTriple(args, "--bind", ro, ro) {
+			t.Errorf("read-only path %q must NOT be bound writable (--bind)\nargs: %v", ro, args)
+		}
+	}
+}

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -150,6 +150,41 @@ else
 fi
 
 echo ""
+echo "=== Session allow-path / allow-read-path ==="
+echo ""
+
+# Use /var/tmp (not /tmp, which bwrap overlays with tmpfs) for a dir OUTSIDE the
+# CWD, to prove the flags grant access beyond the default cwd-only sandbox.
+EXTRA_DIR="/var/tmp/greywall-allowpath-test-$$"
+mkdir -p "$EXTRA_DIR"
+echo "reference data" > "$EXTRA_DIR/ref.txt"
+trap "rm -rf $WORKSPACE $EXTRA_DIR" EXIT
+
+# Negative control: without the flag, writing outside the CWD is denied.
+run_test "write outside CWD blocked (no flag)" "fail" \
+    "$GREYWALL_BIN" -c "echo x > $EXTRA_DIR/nope.txt"
+rm -f "$EXTRA_DIR/nope.txt" 2>/dev/null || true
+
+# --allow-path grants read+write: writing into the extra dir succeeds.
+run_test "--allow-path allows write" "pass" \
+    "$GREYWALL_BIN" --allow-path "$EXTRA_DIR" -c "echo hi > $EXTRA_DIR/out.txt"
+if [[ -f "$EXTRA_DIR/out.txt" ]]; then
+    echo -e "Testing: --allow-path file actually created... ${GREEN}PASS${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "Testing: --allow-path file actually created... ${RED}FAIL${NC} (file does not exist)"
+    FAILED=$((FAILED + 1))
+fi
+
+# --allow-read-path grants read-only: reading succeeds...
+run_test "--allow-read-path allows read" "pass" \
+    "$GREYWALL_BIN" --allow-read-path "$EXTRA_DIR" -c "cat $EXTRA_DIR/ref.txt"
+# ...but writing is still denied.
+run_test "--allow-read-path denies write" "fail" \
+    "$GREYWALL_BIN" --allow-read-path "$EXTRA_DIR" -c "echo x > $EXTRA_DIR/should_fail.txt"
+rm -f "$EXTRA_DIR/should_fail.txt" 2>/dev/null || true
+
+echo ""
 echo "=== Command Blocking ==="
 echo ""
 


### PR DESCRIPTION
## Summary

Greywall is deny-by-default for the filesystem: a sandboxed command can only touch the current working directory (plus system paths). Granting one extra directory or file previously required authoring a profile. These two repeatable flags grant that access **for a single session**, with nothing persisted to disk:

- `--allow-path <path>` — grants **read+write** (appended to `AllowRead` + `AllowWrite`)
- `--allow-read-path <path>` — grants **read-only** (appended to `AllowRead` only)

Since the sandbox is deny-by-default, no `--deny-*` flags are needed.

## Why

A common need is a scratch/temp dir, a sibling project, or a reference dataset for one run — without the ceremony of writing and maintaining a profile. These flags cover that case ergonomically.

## How it works

Both flags accept either a directory or a file, and reuse the existing per-session `AllowRead`/`AllowWrite` plumbing, so they work on **Linux** (bubblewrap + Landlock) and **macOS** (Seatbelt) with no sandbox-layer changes. Paths may be absolute, relative (resolved against CWD), or `~`-prefixed. Grants are applied after profile merge and watch overrides so they always take effect; non-existent paths are tolerated, matching `--allow`.

```bash
greywall --allow-path /tmp/work -- mytool                       # rw scratch dir
greywall --allow-read-path /data/reference.csv -- mytool        # ro single file
greywall --allow-read-path /data/refs --allow-path /tmp/out -- mytool   # mixed
```

## Validation

- Unit test for the flag-merge helper (`applySessionAllowPaths`)
- macOS Seatbelt rule test: read-write vs read-only, including a single-file case (no write rule)
- Linux bind-mount test: `--bind` (rw) vs `--ro-bind` (ro), including a file
- Smoke tests: write-allowed, read-only (write denied), and a negative control
- Manual end-to-end QA on macOS: happy path, single-file scoping (siblings stay denied), relative/`~`/non-existent/empty paths, repeatable + mixed flags, and confirmed an explicit profile `denyWrite` still wins over `--allow-path`

## Checklist

- [x] `make fmt && make lint` clean
- [x] `make test` passing
- [x] Docs updated (`docs/cli-reference.md`)
- [x] Nothing persisted; session-scoped only