### PR TITLE
fix(sandbox): make greyproxy's credential files unreadable inside the Linux sandbox

### DIFF
--- a/internal/sandbox/credentials.go
+++ b/internal/sandbox/credentials.go
@@ -737,20 +737,20 @@ func WarnMaskedEnvFiles(cwd string) {
 
 // SensitiveGreyproxyFiles returns paths to greyproxy files that must not be
 // readable from inside the sandbox (encryption key and CA private key).
+//
+// The list is derived from SensitiveGreyproxyDirs so the per-file deny-READ
+// masks can never drift from the directory masks (e.g. when XDG_DATA_HOME
+// relocates the data dir). See SensitiveGreyproxyDirs for how the candidate
+// directories are resolved.
 func SensitiveGreyproxyFiles() []string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil
+	var files []string
+	for _, dir := range SensitiveGreyproxyDirs() {
+		files = append(files,
+			filepath.Join(dir, "session.key"),
+			filepath.Join(dir, "ca-key.pem"),
+		)
 	}
-
-	return []string{
-		// Linux
-		home + "/.local/share/greyproxy/session.key",
-		home + "/.local/share/greyproxy/ca-key.pem",
-		// macOS
-		home + "/Library/Application Support/greyproxy/session.key",
-		home + "/Library/Application Support/greyproxy/ca-key.pem",
-	}
+	return files
 }
 
 // SensitiveGreyproxyDirs returns greyproxy data directories whose entire
@@ -761,20 +761,27 @@ func SensitiveGreyproxyFiles() []string {
 // Only the public CA certificate (ca-cert.pem) inside these directories is
 // legitimately needed inside the sandbox (for TLS trust); it is re-exposed
 // separately by the sandbox backend.
+//
+// The XDG_DATA_HOME override is resolved INDEPENDENTLY of the home directory:
+// greyproxy (and greyproxyCACertPath) locate the data dir via $XDG_DATA_HOME
+// without needing HOME, so credential substitution can be active while HOME is
+// unset (common in containers / CI / systemd units). Returning early on a home
+// lookup error would then leave the store unmasked while it is still in use — a
+// fail-open leak. We therefore always append the XDG path when set, and only the
+// home-derived defaults depend on the home lookup succeeding.
 func SensitiveGreyproxyDirs() []string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil
+	var dirs []string
+
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs,
+			// Linux (default XDG data home)
+			filepath.Join(home, ".local", "share", "greyproxy"),
+			// macOS
+			filepath.Join(home, "Library", "Application Support", "greyproxy"),
+		)
 	}
 
-	dirs := []string{
-		// Linux (default XDG data home)
-		filepath.Join(home, ".local", "share", "greyproxy"),
-		// macOS
-		filepath.Join(home, "Library", "Application Support", "greyproxy"),
-	}
-
-	// Honor an explicit XDG_DATA_HOME override on Linux.
+	// Honor an explicit XDG_DATA_HOME override (resolvable without HOME).
 	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
 		dirs = append(dirs, filepath.Join(xdg, "greyproxy"))
 	}

--- a/internal/sandbox/credentials.go
+++ b/internal/sandbox/credentials.go
@@ -735,13 +735,9 @@ func WarnMaskedEnvFiles(cwd string) {
 	}
 }
 
-// SensitiveGreyproxyFiles returns paths to greyproxy files that must not be
-// readable from inside the sandbox (encryption key and CA private key).
-//
-// The list is derived from SensitiveGreyproxyDirs so the per-file deny-READ
-// masks can never drift from the directory masks (e.g. when XDG_DATA_HOME
-// relocates the data dir). See SensitiveGreyproxyDirs for how the candidate
-// directories are resolved.
+// SensitiveGreyproxyFiles returns the greyproxy secret files (session key, CA
+// private key) that must not be readable from inside the sandbox. Derived from
+// SensitiveGreyproxyDirs so file and directory masks can't drift.
 func SensitiveGreyproxyFiles() []string {
 	var files []string
 	for _, dir := range SensitiveGreyproxyDirs() {
@@ -753,35 +749,22 @@ func SensitiveGreyproxyFiles() []string {
 	return files
 }
 
-// SensitiveGreyproxyDirs returns greyproxy data directories whose entire
-// contents must not be readable from inside the sandbox: the encrypted
-// credential store (greyproxy.db and its -wal/-shm side files), the session
-// encryption key, the CA private key, and any proxied request/response logs.
+// SensitiveGreyproxyDirs returns the greyproxy data directories whose contents
+// must not be readable from inside the sandbox (encrypted store, session key, CA
+// private key, proxied logs). The public ca-cert.pem is re-exposed separately.
 //
-// Only the public CA certificate (ca-cert.pem) inside these directories is
-// legitimately needed inside the sandbox (for TLS trust); it is re-exposed
-// separately by the sandbox backend.
-//
-// The XDG_DATA_HOME override is resolved INDEPENDENTLY of the home directory:
-// greyproxy (and greyproxyCACertPath) locate the data dir via $XDG_DATA_HOME
-// without needing HOME, so credential substitution can be active while HOME is
-// unset (common in containers / CI / systemd units). Returning early on a home
-// lookup error would then leave the store unmasked while it is still in use — a
-// fail-open leak. We therefore always append the XDG path when set, and only the
-// home-derived defaults depend on the home lookup succeeding.
+// XDG_DATA_HOME is resolved independently of HOME: greyproxy locates the store
+// via $XDG_DATA_HOME without HOME, so a home-lookup error must not drop the mask
+// while substitution is active (that would fail open).
 func SensitiveGreyproxyDirs() []string {
 	var dirs []string
 
 	if home, err := os.UserHomeDir(); err == nil {
 		dirs = append(dirs,
-			// Linux (default XDG data home)
-			filepath.Join(home, ".local", "share", "greyproxy"),
-			// macOS
-			filepath.Join(home, "Library", "Application Support", "greyproxy"),
+			filepath.Join(home, ".local", "share", "greyproxy"),                // Linux default
+			filepath.Join(home, "Library", "Application Support", "greyproxy"), // macOS
 		)
 	}
-
-	// Honor an explicit XDG_DATA_HOME override (resolvable without HOME).
 	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
 		dirs = append(dirs, filepath.Join(xdg, "greyproxy"))
 	}

--- a/internal/sandbox/credentials.go
+++ b/internal/sandbox/credentials.go
@@ -752,3 +752,32 @@ func SensitiveGreyproxyFiles() []string {
 		home + "/Library/Application Support/greyproxy/ca-key.pem",
 	}
 }
+
+// SensitiveGreyproxyDirs returns greyproxy data directories whose entire
+// contents must not be readable from inside the sandbox: the encrypted
+// credential store (greyproxy.db and its -wal/-shm side files), the session
+// encryption key, the CA private key, and any proxied request/response logs.
+//
+// Only the public CA certificate (ca-cert.pem) inside these directories is
+// legitimately needed inside the sandbox (for TLS trust); it is re-exposed
+// separately by the sandbox backend.
+func SensitiveGreyproxyDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	dirs := []string{
+		// Linux (default XDG data home)
+		filepath.Join(home, ".local", "share", "greyproxy"),
+		// macOS
+		filepath.Join(home, "Library", "Application Support", "greyproxy"),
+	}
+
+	// Honor an explicit XDG_DATA_HOME override on Linux.
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		dirs = append(dirs, filepath.Join(xdg, "greyproxy"))
+	}
+
+	return dirs
+}

--- a/internal/sandbox/credentials.go
+++ b/internal/sandbox/credentials.go
@@ -741,7 +741,8 @@ func WarnMaskedEnvFiles(cwd string) {
 func SensitiveGreyproxyFiles() []string {
 	var files []string
 	for _, dir := range SensitiveGreyproxyDirs() {
-		files = append(files,
+		files = append(
+			files,
 			filepath.Join(dir, "session.key"),
 			filepath.Join(dir, "ca-key.pem"),
 		)
@@ -760,7 +761,8 @@ func SensitiveGreyproxyDirs() []string {
 	var dirs []string
 
 	if home, err := os.UserHomeDir(); err == nil {
-		dirs = append(dirs,
+		dirs = append(
+			dirs,
 			filepath.Join(home, ".local", "share", "greyproxy"),                // Linux default
 			filepath.Join(home, "Library", "Application Support", "greyproxy"), // macOS
 		)

--- a/internal/sandbox/dangerous.go
+++ b/internal/sandbox/dangerous.go
@@ -52,13 +52,6 @@ func GetSensitiveProjectPaths(cwd string) []string {
 	return paths
 }
 
-// GetSensitiveSystemPaths returns paths to system files that must be denied
-// from inside the sandbox. These include greyproxy encryption keys and CA
-// private keys that, if leaked, would compromise credential protection.
-func GetSensitiveSystemPaths() []string {
-	return SensitiveGreyproxyFiles()
-}
-
 // GetDefaultWritePaths returns system paths that should be writable for commands to work.
 func GetDefaultWritePaths() []string {
 	home, _ := os.UserHomeDir()

--- a/internal/sandbox/greyproxy_denyread_linux_test.go
+++ b/internal/sandbox/greyproxy_denyread_linux_test.go
@@ -1,0 +1,197 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GreyhavenHQ/greywall/internal/config"
+)
+
+// seedGreyproxyDir creates a fake greyproxy data dir under a temp HOME and
+// returns (home, dataDir). It sets HOME + clears XDG_DATA_HOME so the sandbox
+// path helpers resolve to this dir.
+func seedGreyproxyDir(t *testing.T) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "") // use the default ~/.local/share path
+
+	dataDir := filepath.Join(home, ".local", "share", "greyproxy")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	for _, f := range []string{"session.key", "ca-key.pem", "ca-cert.pem", "greyproxy.db"} {
+		if err := os.WriteFile(filepath.Join(dataDir, f), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	return home, dataDir
+}
+
+// TestGreyproxyDenyReadArgs is a focused regression test for the
+// credential-protection defect where greyproxy's session key, CA private key
+// and encrypted store were left READABLE inside the Linux sandbox.
+//
+// Root cause: the greyproxy secrets were routed through getMandatoryDenyPaths(),
+// which emits the deny-WRITE idiom (--ro-bind realfile realfile). That keeps a
+// path read-only but still readable, and — being emitted after the denyRead
+// /dev/null mask — clobbered it. Separately, the generic ~/.local home-cache
+// bind wholesale-exposed the greyproxy data directory (including greyproxy.db).
+func TestGreyproxyDenyReadArgs(t *testing.T) {
+	_, dataDir := seedGreyproxyDir(t)
+	sessionKey := filepath.Join(dataDir, "session.key")
+	caKey := filepath.Join(dataDir, "ca-key.pem")
+	caCert := filepath.Join(dataDir, "ca-cert.pem")
+	db := filepath.Join(dataDir, "greyproxy.db")
+
+	args := greyproxyDenyReadArgs()
+
+	tmpfsIdx := indexOfPair(args, "--tmpfs", dataDir)
+	if tmpfsIdx < 0 {
+		t.Errorf("expected --tmpfs mask of greyproxy data dir %q; args=%v", dataDir, args)
+	}
+	for _, secret := range []string{sessionKey, caKey} {
+		if indexOfTriple(args, "--ro-bind", "/dev/null", secret) < 0 {
+			t.Errorf("expected %q to be masked with /dev/null; args=%v", secret, args)
+		}
+		if indexOfTriple(args, "--ro-bind", secret, secret) >= 0 {
+			t.Errorf("secret %q is re-exposed read-only as the real file; args=%v", secret, args)
+		}
+	}
+	certIdx := indexOfTriple(args, "--ro-bind", caCert, caCert)
+	if certIdx < 0 {
+		t.Fatalf("expected ca-cert.pem to be re-exposed read-only; args=%v", args)
+	}
+	if tmpfsIdx >= 0 && certIdx < tmpfsIdx {
+		t.Errorf("ca-cert re-bind (%d) must come after the data-dir tmpfs mask (%d) to win", certIdx, tmpfsIdx)
+	}
+	if indexOfTriple(args, "--ro-bind", db, db) >= 0 {
+		t.Errorf("greyproxy.db is re-exposed read-only; args=%v", args)
+	}
+}
+
+// TestGetMandatoryDenyPathsExcludesGreyproxySecrets asserts the greyproxy
+// secrets are NOT routed through the deny-WRITE mandatory path (which would
+// re-expose them readable).
+func TestGetMandatoryDenyPathsExcludesGreyproxySecrets(t *testing.T) {
+	seedGreyproxyDir(t)
+
+	paths := getMandatoryDenyPaths(t.TempDir())
+	for _, secret := range SensitiveGreyproxyFiles() {
+		for _, p := range paths {
+			if p == secret {
+				t.Errorf("greyproxy secret %q must not be in getMandatoryDenyPaths (deny-write re-exposes it readable)", secret)
+			}
+		}
+	}
+}
+
+// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch is the real
+// integration assertion: it drives the FULL wrapper (WrapCommandLinuxWithOptions)
+// in BOTH the enforcing path and --watch mode, with a greyproxy data dir present
+// (i.e. credential substitution active), and verifies against the complete
+// generated bwrap command that:
+//
+//   - the data dir is masked with an empty tmpfs and the key files with
+//     /dev/null;
+//   - NO later bind re-exposes session.key / ca-key.pem / greyproxy.db (neither
+//     a real-file ro-bind nor an ancestor bind emitted after the mask);
+//   - ca-cert.pem stays readable.
+//
+// It would fail if the mask helper is skipped (the --watch bypass bug) or
+// appended before a clobbering bind — the two ways the isolated helper test
+// could be defeated.
+func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
+	modes := []struct {
+		name string
+		opts LinuxSandboxOptions
+	}{
+		{"enforcing", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}},
+		{"watch", LinuxSandboxOptions{Watch: true}},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			home, dataDir := seedGreyproxyDir(t)
+			// Deny-by-default (DefaultDenyRead nil => true) exercises the
+			// ~/.local home-cache bind that originally clobbered the mask.
+			cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
+
+			cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, nil, nil, nil, "", m.opts)
+			if err != nil {
+				t.Fatalf("[%s] wrap failed: %v", m.name, err)
+			}
+
+			sk := filepath.Join(dataDir, "session.key")
+			ck := filepath.Join(dataDir, "ca-key.pem")
+			cc := filepath.Join(dataDir, "ca-cert.pem")
+			db := filepath.Join(dataDir, "greyproxy.db")
+
+			tmpfsMask := "--tmpfs " + dataDir
+			maskAt := strings.LastIndex(cmd, tmpfsMask)
+			if maskAt < 0 {
+				t.Fatalf("[%s] greyproxy data dir not masked with tmpfs; the mask is not applied in this mode", m.name)
+			}
+
+			// Key files masked with /dev/null, never re-exposed as real files.
+			for _, p := range []string{sk, ck} {
+				if !strings.Contains(cmd, "--ro-bind /dev/null "+p) {
+					t.Errorf("[%s] %q not masked with /dev/null", m.name, p)
+				}
+			}
+			for _, p := range []string{sk, ck, db} {
+				if strings.Contains(cmd, "--ro-bind "+p+" "+p) {
+					t.Errorf("[%s] secret %q re-exposed as the real file", m.name, p)
+				}
+			}
+
+			// ca-cert.pem stays readable, and its re-bind wins over the mask.
+			ccReBind := "--ro-bind " + cc + " " + cc
+			ccAt := strings.LastIndex(cmd, ccReBind)
+			if ccAt < 0 {
+				t.Errorf("[%s] ca-cert.pem not re-exposed read-only (TLS trust broken)", m.name)
+			} else if ccAt < maskAt {
+				t.Errorf("[%s] ca-cert re-bind (%d) must come after the dir mask (%d)", m.name, ccAt, maskAt)
+			}
+
+			// Nothing may re-expose the secrets AFTER the mask: assert every
+			// bind of an ancestor directory of the greyproxy dir is emitted
+			// BEFORE the mask (so "last mount wins" keeps the mask in effect).
+			ancestors := []string{
+				"--bind " + home + " " + home,                                                      // watch: writable home
+				"--ro-bind " + home + " " + home,                                                   // legacy home ro-bind
+				"--ro-bind " + filepath.Join(home, ".local") + " " + filepath.Join(home, ".local"), // deny-default home cache
+			}
+			for _, anc := range ancestors {
+				if i := strings.LastIndex(cmd, anc); i >= 0 && i > maskAt {
+					t.Errorf("[%s] ancestor bind %q at %d re-exposes greyproxy secrets AFTER the mask at %d", m.name, anc, i, maskAt)
+				}
+			}
+		})
+	}
+}
+
+// indexOfPair returns the index of a two-token mount arg (flag, dest), or -1.
+func indexOfPair(args []string, flag, dest string) int {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == dest {
+			return i
+		}
+	}
+	return -1
+}
+
+// indexOfTriple returns the index of a three-token mount arg (flag, src, dest),
+// or -1.
+func indexOfTriple(args []string, flag, src, dest string) int {
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == flag && args[i+1] == src && args[i+2] == dest {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/sandbox/greyproxy_denyread_linux_test.go
+++ b/internal/sandbox/greyproxy_denyread_linux_test.go
@@ -19,7 +19,7 @@ import (
 func seedGreyproxyDirIn(t *testing.T, parent string) string {
 	t.Helper()
 	dataDir := filepath.Join(parent, "greyproxy")
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		t.Fatalf("mkdir data dir: %v", err)
 	}
 	for _, f := range []string{"session.key", "ca-key.pem", "ca-cert.pem", "greyproxy.db"} {
@@ -320,7 +320,7 @@ func TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime(t *testing.T) {
 		t.Fatalf("wrap: %v", err)
 	}
 
-	out, runErr := exec.Command("bash", "-c", cmd).CombinedOutput()
+	out, runErr := exec.Command("bash", "-c", cmd).CombinedOutput() //nolint:gosec // test runs the greywall-generated sandbox command
 	got := string(out)
 
 	// If bubblewrap can't stand up a namespace here, skip rather than fail.

--- a/internal/sandbox/greyproxy_denyread_linux_test.go
+++ b/internal/sandbox/greyproxy_denyread_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -280,24 +281,15 @@ func TestSensitiveGreyproxyPathsHonorXDG(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", xdg)
 
 	wantDir := filepath.Join(xdg, "greyproxy")
-	if !contains(SensitiveGreyproxyDirs(), wantDir) {
+	if !slices.Contains(SensitiveGreyproxyDirs(), wantDir) {
 		t.Errorf("SensitiveGreyproxyDirs missing XDG dir %q: %v", wantDir, SensitiveGreyproxyDirs())
 	}
 	for _, f := range []string{"session.key", "ca-key.pem"} {
 		want := filepath.Join(wantDir, f)
-		if !contains(SensitiveGreyproxyFiles(), want) {
+		if !slices.Contains(SensitiveGreyproxyFiles(), want) {
 			t.Errorf("SensitiveGreyproxyFiles missing XDG secret %q: %v", want, SensitiveGreyproxyFiles())
 		}
 	}
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
 }
 
 // TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime runs real bubblewrap
@@ -305,12 +297,8 @@ func contains(haystack []string, needle string) bool {
 // masked path reads empty and a re-exposed one reads "x". Skips when bwrap can't
 // create a namespace (e.g. unprivileged CI), per repo convention.
 func TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime(t *testing.T) {
-	if os.Getenv("GREYWALL_SANDBOX") == "1" {
-		t.Skip("skipping: already running inside a sandbox")
-	}
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("skipping: bwrap not found")
-	}
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "bwrap")
 
 	_, dataDir := seedGreyproxyDir(t)
 	cfg := &config.Config{Filesystem: config.FilesystemConfig{}}

--- a/internal/sandbox/greyproxy_denyread_linux_test.go
+++ b/internal/sandbox/greyproxy_denyread_linux_test.go
@@ -48,12 +48,9 @@ type bwrapMount struct {
 	dest string
 }
 
-// parseBwrapMounts extracts the filesystem-mount arguments (in emission order)
-// from a generated bwrap command string. It considers only the portion BEFORE
-// the "--" command separator (everything after is the inner script, a single
-// quoted blob). It relies on the seeded paths containing no spaces or shell
-// metacharacters (t.TempDir on Linux) so ShellQuote leaves the mount args
-// untouched and strings.Fields recovers the tokens faithfully.
+// parseBwrapMounts extracts the mount args (in order) from a generated command,
+// ignoring everything after the "--" separator (the inner script). Assumes the
+// seeded paths have no spaces (t.TempDir on Linux) so Fields recovers tokens.
 func parseBwrapMounts(cmd string) []bwrapMount {
 	if i := strings.Index(cmd, " -- "); i >= 0 {
 		cmd = cmd[:i]
@@ -77,9 +74,8 @@ func parseBwrapMounts(cmd string) []bwrapMount {
 	return mounts
 }
 
-// lastDestIndex returns the index of the LAST mount whose dest == path, or -1.
-// Because bwrap follows "last mount wins", the mount at this index is the one
-// that is actually in effect at that path.
+// lastDestIndex returns the index of the last mount whose dest == path (the one
+// in effect under "last mount wins"), or -1.
 func lastDestIndex(mounts []bwrapMount, path string) int {
 	idx := -1
 	for i, m := range mounts {
@@ -90,10 +86,8 @@ func lastDestIndex(mounts []bwrapMount, path string) int {
 	return idx
 }
 
-// ancestorsOf returns every proper ancestor directory of path up to the
-// filesystem root ("/home/u/.local/share/greyproxy" -> ".local/share", ".local",
-// the home dir, ... , "/"). A bind of ANY of these that lands after the mask
-// would re-expose the greyproxy subtree.
+// ancestorsOf returns every proper ancestor directory of path up to "/". A bind
+// of any of these landing after the mask would re-expose the subtree.
 func ancestorsOf(path string) []string {
 	var out []string
 	for p := filepath.Dir(path); ; p = filepath.Dir(p) {
@@ -105,17 +99,9 @@ func ancestorsOf(path string) []string {
 	return out
 }
 
-// assertGreyproxyMaskWins is the core invariant check. Given the parsed mounts
-// of a generated command and the seeded data dir, it asserts that:
-//   - the data dir is masked with an empty tmpfs, and that tmpfs is the LAST
-//     mount targeting the data dir (so any earlier bind — including a hostile
-//     bridge socket dir placed inside it — is overridden);
-//   - NO ancestor directory of the data dir is bound AFTER the mask;
-//   - session.key / ca-key.pem are effectively /dev/null (their last mount has
-//     src == /dev/null), never re-exposed as the real file;
-//   - greyproxy.db is never the last mount at its own path as a real file;
-//   - ca-cert.pem IS re-exposed as the real file, and that re-bind wins over the
-//     tmpfs (comes after it).
+// assertGreyproxyMaskWins asserts the effective (last-wins) mounts leave the
+// data dir a tmpfs, no ancestor re-bound after it, the secret files masked with
+// /dev/null, greyproxy.db not re-exposed, and ca-cert.pem readable.
 func assertGreyproxyMaskWins(t *testing.T, mounts []bwrapMount, dataDir string) {
 	t.Helper()
 
@@ -128,9 +114,7 @@ func assertGreyproxyMaskWins(t *testing.T, mounts []bwrapMount, dataDir string) 
 			dataDir, mounts[maskIdx].flag, mounts[maskIdx].src, mounts)
 	}
 
-	// Generic ancestor check: no ancestor of the data dir may be (re-)bound after
-	// the mask, regardless of flag or exact path. This is what catches an
-	// unlisted clobbering ancestor (e.g. ~/.local, ~/.local/share, $HOME, /).
+	// No ancestor may be (re-)bound after the mask, whatever the flag or path.
 	for _, anc := range ancestorsOf(dataDir) {
 		if i := lastDestIndex(mounts, anc); i > maskIdx {
 			t.Errorf("ancestor %q is bound at index %d, AFTER the data-dir mask at %d — it re-exposes the greyproxy secrets; mounts=%+v",
@@ -138,17 +122,13 @@ func assertGreyproxyMaskWins(t *testing.T, mounts []bwrapMount, dataDir string) 
 		}
 	}
 
-	// Secret files: their effective (last) mount must be /dev/null, never the
-	// real file.
+	// Each secret file's effective mount must be /dev/null, never the real file.
 	for _, secret := range []string{
 		filepath.Join(dataDir, "session.key"),
 		filepath.Join(dataDir, "ca-key.pem"),
 	} {
 		i := lastDestIndex(mounts, secret)
 		if i < 0 {
-			// Covered solely by the dir tmpfs — acceptable, but the fix also
-			// emits an explicit /dev/null mask, so flag its absence as a
-			// defense-in-depth regression.
 			t.Errorf("secret %q has no explicit /dev/null mask (defense-in-depth); mounts=%+v", secret, mounts)
 			continue
 		}
@@ -158,7 +138,6 @@ func assertGreyproxyMaskWins(t *testing.T, mounts []bwrapMount, dataDir string) 
 		}
 	}
 
-	// greyproxy.db must never end up re-exposed as the real file.
 	db := filepath.Join(dataDir, "greyproxy.db")
 	if i := lastDestIndex(mounts, db); i >= 0 && mounts[i].src == db {
 		t.Errorf("greyproxy.db is re-exposed as the real file at index %d; mounts=%+v", i, mounts)
@@ -174,12 +153,8 @@ func assertGreyproxyMaskWins(t *testing.T, mounts []bwrapMount, dataDir string) 
 	}
 }
 
-// TestGreyproxyDenyReadArgs is a focused unit test for the deny-READ helper in
-// isolation: tmpfs on the data dir, /dev/null on each secret file, real
-// ca-cert re-exposed, no real-file re-bind of the secrets.
-//
-// It cannot observe clobbering by OTHER binds in the full command — that is what
-// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch covers.
+// TestGreyproxyDenyReadArgs unit-tests the helper in isolation. Clobbering by
+// other binds is covered by TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch.
 func TestGreyproxyDenyReadArgs(t *testing.T) {
 	_, dataDir := seedGreyproxyDir(t)
 	sessionKey := filepath.Join(dataDir, "session.key")
@@ -206,9 +181,8 @@ func TestGreyproxyDenyReadArgs(t *testing.T) {
 	}
 }
 
-// TestGetMandatoryDenyPathsExcludesGreyproxySecrets asserts the greyproxy
-// secrets are NOT routed through the deny-WRITE mandatory path (which would
-// re-expose them readable).
+// TestGetMandatoryDenyPathsExcludesGreyproxySecrets asserts the secrets aren't
+// routed through the deny-WRITE path (which would leave them readable).
 func TestGetMandatoryDenyPathsExcludesGreyproxySecrets(t *testing.T) {
 	seedGreyproxyDir(t)
 
@@ -222,16 +196,10 @@ func TestGetMandatoryDenyPathsExcludesGreyproxySecrets(t *testing.T) {
 	}
 }
 
-// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch drives the FULL
-// wrapper and asserts the deny-READ invariant against the complete generated
-// command in every mode where credential substitution can be active:
-//   - enforcing and --watch (the mask must apply in both; only learning is
-//     exempt);
-//   - with and without a HOSTILE reverse bridge whose socket dir is the greyproxy
-//     data dir itself, which emits a "--bind <data-dir> <data-dir>" AFTER the
-//     older mask position. This exercises the post-mask append region (bridge
-//     socket dirs, greywall exe bind, etc.) that a bridges-nil config never
-//     reaches, and would FAIL if the mask were not emitted genuinely last.
+// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch drives the full
+// wrapper in enforcing and --watch modes. The hostile cases add a reverse bridge
+// whose socket dir is the data dir, emitting a "--bind <data-dir> <data-dir>" in
+// the post-mask region — which fails unless the mask is emitted genuinely last.
 func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -247,14 +215,13 @@ func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, dataDir := seedGreyproxyDir(t)
-			// Deny-by-default (DefaultDenyRead nil => true) exercises the
-			// ~/.local home-cache bind that originally clobbered the mask.
+			// Deny-by-default exercises the ~/.local home-cache bind that
+			// originally clobbered the mask.
 			cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
 
 			var reverseBridge *ReverseBridge
 			if tc.hostile {
-				// Ports left nil so the inner-script socat loop is skipped; the
-				// mount bind of filepath.Dir(socket)==dataDir still fires.
+				// Nil Ports skips the socat loop; the socket-dir bind still fires.
 				reverseBridge = &ReverseBridge{SocketPaths: []string{filepath.Join(dataDir, "rev.sock")}}
 			}
 
@@ -267,9 +234,8 @@ func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
 			assertGreyproxyMaskWins(t, mounts, dataDir)
 
 			if tc.hostile {
-				// Sanity: the regression scenario is actually present — a real
-				// --bind of the data dir exists before the mask. Without this,
-				// the test would pass vacuously if the bind were ever dropped.
+				// Sanity: confirm the hostile --bind is actually present (before
+				// the mask), so the test can't pass vacuously.
 				maskIdx := lastDestIndex(mounts, dataDir)
 				found := false
 				for i, m := range mounts {
@@ -287,10 +253,7 @@ func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
 }
 
 // TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome guards the XDG_DATA_HOME
-// relocation path: greyproxy's dir and per-file secrets must still be masked
-// when the store lives at $XDG_DATA_HOME/greyproxy. This would fail if
-// SensitiveGreyproxyFiles() stopped honoring XDG (the per-file /dev/null masks
-// would silently no-op).
+// relocation: the store must still be masked when it lives at $XDG_DATA_HOME.
 func TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome(t *testing.T) {
 	home := t.TempDir()
 	xdg := t.TempDir()
@@ -308,9 +271,8 @@ func TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome(t *testing.T) {
 	assertGreyproxyMaskWins(t, parseBwrapMounts(cmd), dataDir)
 }
 
-// TestSensitiveGreyproxyPathsHonorXDG asserts the path helpers include the
-// XDG_DATA_HOME location for both dirs and per-file secrets, so dir and file
-// masks cannot diverge.
+// TestSensitiveGreyproxyPathsHonorXDG asserts both helpers include the
+// XDG_DATA_HOME location, so dir and file masks can't diverge.
 func TestSensitiveGreyproxyPathsHonorXDG(t *testing.T) {
 	home := t.TempDir()
 	xdg := t.TempDir()
@@ -338,15 +300,10 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
-// TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime complements the
-// command-string assertions with REAL bubblewrap enforcement: it executes the
-// generated sandbox and, from inside it, reads each greyproxy path. The seeded
-// files each contain "x", so a masked path reads empty and a re-exposed one
-// reads "x". It asserts session.key / ca-key.pem / greyproxy.db are empty
-// (masked) while the public ca-cert.pem is readable (TLS trust preserved).
-//
-// Per repo convention for runtime sandbox tests, it skips when bwrap is absent
-// or cannot create user namespaces (e.g. unprivileged CI).
+// TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime runs real bubblewrap
+// and reads each path from inside the sandbox. Seeded files contain "x", so a
+// masked path reads empty and a re-exposed one reads "x". Skips when bwrap can't
+// create a namespace (e.g. unprivileged CI), per repo convention.
 func TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime(t *testing.T) {
 	if os.Getenv("GREYWALL_SANDBOX") == "1" {
 		t.Skip("skipping: already running inside a sandbox")

--- a/internal/sandbox/greyproxy_denyread_linux_test.go
+++ b/internal/sandbox/greyproxy_denyread_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -198,24 +197,35 @@ func TestGetMandatoryDenyPathsExcludesGreyproxySecrets(t *testing.T) {
 }
 
 // TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch drives the full
-// wrapper in enforcing and --watch modes. The hostile cases add a reverse bridge
-// whose socket dir is the data dir, emitting a "--bind <data-dir> <data-dir>" in
-// the post-mask region — which fails unless the mask is emitted genuinely last.
+// wrapper in enforcing and --watch modes, plus an XDG_DATA_HOME relocation. The
+// hostile cases add a reverse bridge whose socket dir is the data dir, emitting a
+// "--bind <data-dir> <data-dir>" in the post-mask region — which fails unless the
+// mask is emitted genuinely last.
 func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
 	cases := []struct {
 		name    string
 		opts    LinuxSandboxOptions
 		hostile bool // add a reverse bridge whose socket dir == the greyproxy data dir
+		xdg     bool // relocate the store to $XDG_DATA_HOME instead of ~/.local/share
 	}{
-		{"enforcing", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, false},
-		{"watch", LinuxSandboxOptions{Watch: true}, false},
-		{"enforcing_hostile_reverse_bridge", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, true},
-		{"watch_hostile_reverse_bridge", LinuxSandboxOptions{Watch: true}, true},
+		{"enforcing", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, false, false},
+		{"watch", LinuxSandboxOptions{Watch: true}, false, false},
+		{"enforcing_hostile_reverse_bridge", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, true, false},
+		{"watch_hostile_reverse_bridge", LinuxSandboxOptions{Watch: true}, true, false},
+		{"enforcing_xdg_data_home", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, false, true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, dataDir := seedGreyproxyDir(t)
+			var dataDir string
+			if tc.xdg {
+				t.Setenv("HOME", t.TempDir())
+				xdg := t.TempDir()
+				t.Setenv("XDG_DATA_HOME", xdg)
+				dataDir = seedGreyproxyDirIn(t, xdg)
+			} else {
+				_, dataDir = seedGreyproxyDir(t)
+			}
 			// Deny-by-default exercises the ~/.local home-cache bind that
 			// originally clobbered the mask.
 			cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
@@ -250,45 +260,6 @@ func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome guards the XDG_DATA_HOME
-// relocation: the store must still be masked when it lives at $XDG_DATA_HOME.
-func TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome(t *testing.T) {
-	home := t.TempDir()
-	xdg := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_DATA_HOME", xdg)
-
-	dataDir := seedGreyproxyDirIn(t, xdg)
-	cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
-
-	cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, nil, nil, nil, "", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true})
-	if err != nil {
-		t.Fatalf("wrap failed: %v", err)
-	}
-
-	assertGreyproxyMaskWins(t, parseBwrapMounts(cmd), dataDir)
-}
-
-// TestSensitiveGreyproxyPathsHonorXDG asserts both helpers include the
-// XDG_DATA_HOME location, so dir and file masks can't diverge.
-func TestSensitiveGreyproxyPathsHonorXDG(t *testing.T) {
-	home := t.TempDir()
-	xdg := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_DATA_HOME", xdg)
-
-	wantDir := filepath.Join(xdg, "greyproxy")
-	if !slices.Contains(SensitiveGreyproxyDirs(), wantDir) {
-		t.Errorf("SensitiveGreyproxyDirs missing XDG dir %q: %v", wantDir, SensitiveGreyproxyDirs())
-	}
-	for _, f := range []string{"session.key", "ca-key.pem"} {
-		want := filepath.Join(wantDir, f)
-		if !slices.Contains(SensitiveGreyproxyFiles(), want) {
-			t.Errorf("SensitiveGreyproxyFiles missing XDG secret %q: %v", want, SensitiveGreyproxyFiles())
-		}
 	}
 }
 

--- a/internal/sandbox/greyproxy_denyread_linux_test.go
+++ b/internal/sandbox/greyproxy_denyread_linux_test.go
@@ -4,6 +4,7 @@ package sandbox
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,16 +12,12 @@ import (
 	"github.com/GreyhavenHQ/greywall/internal/config"
 )
 
-// seedGreyproxyDir creates a fake greyproxy data dir under a temp HOME and
-// returns (home, dataDir). It sets HOME + clears XDG_DATA_HOME so the sandbox
-// path helpers resolve to this dir.
-func seedGreyproxyDir(t *testing.T) (string, string) {
+// seedGreyproxyDirIn creates a fake greyproxy data dir at <parent>/greyproxy,
+// populated with the sensitive files plus the public ca-cert, and returns the
+// data dir path.
+func seedGreyproxyDirIn(t *testing.T, parent string) string {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_DATA_HOME", "") // use the default ~/.local/share path
-
-	dataDir := filepath.Join(home, ".local", "share", "greyproxy")
+	dataDir := filepath.Join(parent, "greyproxy")
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		t.Fatalf("mkdir data dir: %v", err)
 	}
@@ -29,18 +26,160 @@ func seedGreyproxyDir(t *testing.T) (string, string) {
 			t.Fatalf("write %s: %v", f, err)
 		}
 	}
+	return dataDir
+}
+
+// seedGreyproxyDir creates a fake greyproxy data dir under a temp HOME using the
+// default (~/.local/share) layout and returns (home, dataDir). It sets HOME and
+// clears XDG_DATA_HOME so the sandbox path helpers resolve to this dir.
+func seedGreyproxyDir(t *testing.T) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "") // use the default ~/.local/share path
+	dataDir := seedGreyproxyDirIn(t, filepath.Join(home, ".local", "share"))
 	return home, dataDir
 }
 
-// TestGreyproxyDenyReadArgs is a focused regression test for the
-// credential-protection defect where greyproxy's session key, CA private key
-// and encrypted store were left READABLE inside the Linux sandbox.
+// bwrapMount is a parsed filesystem-mount argument from the generated command.
+type bwrapMount struct {
+	flag string // --tmpfs / --ro-bind / --bind / --dev-bind
+	src  string // "" for --tmpfs
+	dest string
+}
+
+// parseBwrapMounts extracts the filesystem-mount arguments (in emission order)
+// from a generated bwrap command string. It considers only the portion BEFORE
+// the "--" command separator (everything after is the inner script, a single
+// quoted blob). It relies on the seeded paths containing no spaces or shell
+// metacharacters (t.TempDir on Linux) so ShellQuote leaves the mount args
+// untouched and strings.Fields recovers the tokens faithfully.
+func parseBwrapMounts(cmd string) []bwrapMount {
+	if i := strings.Index(cmd, " -- "); i >= 0 {
+		cmd = cmd[:i]
+	}
+	toks := strings.Fields(cmd)
+	var mounts []bwrapMount
+	for i := 0; i < len(toks); i++ {
+		switch toks[i] {
+		case "--tmpfs":
+			if i+1 < len(toks) {
+				mounts = append(mounts, bwrapMount{flag: toks[i], dest: toks[i+1]})
+				i++
+			}
+		case "--ro-bind", "--ro-bind-try", "--bind", "--bind-try", "--dev-bind":
+			if i+2 < len(toks) {
+				mounts = append(mounts, bwrapMount{flag: toks[i], src: toks[i+1], dest: toks[i+2]})
+				i += 2
+			}
+		}
+	}
+	return mounts
+}
+
+// lastDestIndex returns the index of the LAST mount whose dest == path, or -1.
+// Because bwrap follows "last mount wins", the mount at this index is the one
+// that is actually in effect at that path.
+func lastDestIndex(mounts []bwrapMount, path string) int {
+	idx := -1
+	for i, m := range mounts {
+		if m.dest == path {
+			idx = i
+		}
+	}
+	return idx
+}
+
+// ancestorsOf returns every proper ancestor directory of path up to the
+// filesystem root ("/home/u/.local/share/greyproxy" -> ".local/share", ".local",
+// the home dir, ... , "/"). A bind of ANY of these that lands after the mask
+// would re-expose the greyproxy subtree.
+func ancestorsOf(path string) []string {
+	var out []string
+	for p := filepath.Dir(path); ; p = filepath.Dir(p) {
+		out = append(out, p)
+		if parent := filepath.Dir(p); parent == p {
+			break
+		}
+	}
+	return out
+}
+
+// assertGreyproxyMaskWins is the core invariant check. Given the parsed mounts
+// of a generated command and the seeded data dir, it asserts that:
+//   - the data dir is masked with an empty tmpfs, and that tmpfs is the LAST
+//     mount targeting the data dir (so any earlier bind — including a hostile
+//     bridge socket dir placed inside it — is overridden);
+//   - NO ancestor directory of the data dir is bound AFTER the mask;
+//   - session.key / ca-key.pem are effectively /dev/null (their last mount has
+//     src == /dev/null), never re-exposed as the real file;
+//   - greyproxy.db is never the last mount at its own path as a real file;
+//   - ca-cert.pem IS re-exposed as the real file, and that re-bind wins over the
+//     tmpfs (comes after it).
+func assertGreyproxyMaskWins(t *testing.T, mounts []bwrapMount, dataDir string) {
+	t.Helper()
+
+	maskIdx := lastDestIndex(mounts, dataDir)
+	if maskIdx < 0 {
+		t.Fatalf("greyproxy data dir %q is never mounted/masked; mounts=%+v", dataDir, mounts)
+	}
+	if mounts[maskIdx].flag != "--tmpfs" {
+		t.Fatalf("last mount at data dir %q is %q (src=%q), want --tmpfs mask — the mask was clobbered; mounts=%+v",
+			dataDir, mounts[maskIdx].flag, mounts[maskIdx].src, mounts)
+	}
+
+	// Generic ancestor check: no ancestor of the data dir may be (re-)bound after
+	// the mask, regardless of flag or exact path. This is what catches an
+	// unlisted clobbering ancestor (e.g. ~/.local, ~/.local/share, $HOME, /).
+	for _, anc := range ancestorsOf(dataDir) {
+		if i := lastDestIndex(mounts, anc); i > maskIdx {
+			t.Errorf("ancestor %q is bound at index %d, AFTER the data-dir mask at %d — it re-exposes the greyproxy secrets; mounts=%+v",
+				anc, i, maskIdx, mounts)
+		}
+	}
+
+	// Secret files: their effective (last) mount must be /dev/null, never the
+	// real file.
+	for _, secret := range []string{
+		filepath.Join(dataDir, "session.key"),
+		filepath.Join(dataDir, "ca-key.pem"),
+	} {
+		i := lastDestIndex(mounts, secret)
+		if i < 0 {
+			// Covered solely by the dir tmpfs — acceptable, but the fix also
+			// emits an explicit /dev/null mask, so flag its absence as a
+			// defense-in-depth regression.
+			t.Errorf("secret %q has no explicit /dev/null mask (defense-in-depth); mounts=%+v", secret, mounts)
+			continue
+		}
+		if mounts[i].src != "/dev/null" {
+			t.Errorf("secret %q effective mount is %q from src %q, want --ro-bind /dev/null (real file re-exposed); mounts=%+v",
+				secret, mounts[i].flag, mounts[i].src, mounts)
+		}
+	}
+
+	// greyproxy.db must never end up re-exposed as the real file.
+	db := filepath.Join(dataDir, "greyproxy.db")
+	if i := lastDestIndex(mounts, db); i >= 0 && mounts[i].src == db {
+		t.Errorf("greyproxy.db is re-exposed as the real file at index %d; mounts=%+v", i, mounts)
+	}
+
+	// ca-cert.pem must be re-exposed (TLS trust) and win over the tmpfs.
+	cc := filepath.Join(dataDir, "ca-cert.pem")
+	i := lastDestIndex(mounts, cc)
+	if i < 0 || mounts[i].src != cc {
+		t.Errorf("ca-cert.pem not re-exposed as the real file (TLS trust broken); mounts=%+v", mounts)
+	} else if i < maskIdx {
+		t.Errorf("ca-cert re-bind at %d precedes the data-dir mask at %d — it would be wiped by the tmpfs; mounts=%+v", i, maskIdx, mounts)
+	}
+}
+
+// TestGreyproxyDenyReadArgs is a focused unit test for the deny-READ helper in
+// isolation: tmpfs on the data dir, /dev/null on each secret file, real
+// ca-cert re-exposed, no real-file re-bind of the secrets.
 //
-// Root cause: the greyproxy secrets were routed through getMandatoryDenyPaths(),
-// which emits the deny-WRITE idiom (--ro-bind realfile realfile). That keeps a
-// path read-only but still readable, and — being emitted after the denyRead
-// /dev/null mask — clobbered it. Separately, the generic ~/.local home-cache
-// bind wholesale-exposed the greyproxy data directory (including greyproxy.db).
+// It cannot observe clobbering by OTHER binds in the full command — that is what
+// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch covers.
 func TestGreyproxyDenyReadArgs(t *testing.T) {
 	_, dataDir := seedGreyproxyDir(t)
 	sessionKey := filepath.Join(dataDir, "session.key")
@@ -48,29 +187,22 @@ func TestGreyproxyDenyReadArgs(t *testing.T) {
 	caCert := filepath.Join(dataDir, "ca-cert.pem")
 	db := filepath.Join(dataDir, "greyproxy.db")
 
-	args := greyproxyDenyReadArgs()
+	mounts := parseBwrapMounts(strings.Join(greyproxyDenyReadArgs(), " "))
 
-	tmpfsIdx := indexOfPair(args, "--tmpfs", dataDir)
-	if tmpfsIdx < 0 {
-		t.Errorf("expected --tmpfs mask of greyproxy data dir %q; args=%v", dataDir, args)
+	if i := lastDestIndex(mounts, dataDir); i < 0 || mounts[i].flag != "--tmpfs" {
+		t.Errorf("expected --tmpfs mask of greyproxy data dir %q; mounts=%+v", dataDir, mounts)
 	}
 	for _, secret := range []string{sessionKey, caKey} {
-		if indexOfTriple(args, "--ro-bind", "/dev/null", secret) < 0 {
-			t.Errorf("expected %q to be masked with /dev/null; args=%v", secret, args)
-		}
-		if indexOfTriple(args, "--ro-bind", secret, secret) >= 0 {
-			t.Errorf("secret %q is re-exposed read-only as the real file; args=%v", secret, args)
+		i := lastDestIndex(mounts, secret)
+		if i < 0 || mounts[i].src != "/dev/null" {
+			t.Errorf("expected %q masked with /dev/null; mounts=%+v", secret, mounts)
 		}
 	}
-	certIdx := indexOfTriple(args, "--ro-bind", caCert, caCert)
-	if certIdx < 0 {
-		t.Fatalf("expected ca-cert.pem to be re-exposed read-only; args=%v", args)
+	if i := lastDestIndex(mounts, caCert); i < 0 || mounts[i].src != caCert {
+		t.Errorf("expected ca-cert.pem re-exposed read-only; mounts=%+v", mounts)
 	}
-	if tmpfsIdx >= 0 && certIdx < tmpfsIdx {
-		t.Errorf("ca-cert re-bind (%d) must come after the data-dir tmpfs mask (%d) to win", certIdx, tmpfsIdx)
-	}
-	if indexOfTriple(args, "--ro-bind", db, db) >= 0 {
-		t.Errorf("greyproxy.db is re-exposed read-only; args=%v", args)
+	if i := lastDestIndex(mounts, db); i >= 0 && mounts[i].src == db {
+		t.Errorf("greyproxy.db re-exposed as the real file; mounts=%+v", mounts)
 	}
 }
 
@@ -90,108 +222,178 @@ func TestGetMandatoryDenyPathsExcludesGreyproxySecrets(t *testing.T) {
 	}
 }
 
-// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch is the real
-// integration assertion: it drives the FULL wrapper (WrapCommandLinuxWithOptions)
-// in BOTH the enforcing path and --watch mode, with a greyproxy data dir present
-// (i.e. credential substitution active), and verifies against the complete
-// generated bwrap command that:
-//
-//   - the data dir is masked with an empty tmpfs and the key files with
-//     /dev/null;
-//   - NO later bind re-exposes session.key / ca-key.pem / greyproxy.db (neither
-//     a real-file ro-bind nor an ancestor bind emitted after the mask);
-//   - ca-cert.pem stays readable.
-//
-// It would fail if the mask helper is skipped (the --watch bypass bug) or
-// appended before a clobbering bind — the two ways the isolated helper test
-// could be defeated.
+// TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch drives the FULL
+// wrapper and asserts the deny-READ invariant against the complete generated
+// command in every mode where credential substitution can be active:
+//   - enforcing and --watch (the mask must apply in both; only learning is
+//     exempt);
+//   - with and without a HOSTILE reverse bridge whose socket dir is the greyproxy
+//     data dir itself, which emits a "--bind <data-dir> <data-dir>" AFTER the
+//     older mask position. This exercises the post-mask append region (bridge
+//     socket dirs, greywall exe bind, etc.) that a bridges-nil config never
+//     reaches, and would FAIL if the mask were not emitted genuinely last.
 func TestWrapCommandLinux_GreyproxySecretsMaskedIncludingWatch(t *testing.T) {
-	modes := []struct {
-		name string
-		opts LinuxSandboxOptions
+	cases := []struct {
+		name    string
+		opts    LinuxSandboxOptions
+		hostile bool // add a reverse bridge whose socket dir == the greyproxy data dir
 	}{
-		{"enforcing", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}},
-		{"watch", LinuxSandboxOptions{Watch: true}},
+		{"enforcing", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, false},
+		{"watch", LinuxSandboxOptions{Watch: true}, false},
+		{"enforcing_hostile_reverse_bridge", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true}, true},
+		{"watch_hostile_reverse_bridge", LinuxSandboxOptions{Watch: true}, true},
 	}
 
-	for _, m := range modes {
-		t.Run(m.name, func(t *testing.T) {
-			home, dataDir := seedGreyproxyDir(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, dataDir := seedGreyproxyDir(t)
 			// Deny-by-default (DefaultDenyRead nil => true) exercises the
 			// ~/.local home-cache bind that originally clobbered the mask.
 			cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
 
-			cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, nil, nil, nil, "", m.opts)
+			var reverseBridge *ReverseBridge
+			if tc.hostile {
+				// Ports left nil so the inner-script socat loop is skipped; the
+				// mount bind of filepath.Dir(socket)==dataDir still fires.
+				reverseBridge = &ReverseBridge{SocketPaths: []string{filepath.Join(dataDir, "rev.sock")}}
+			}
+
+			cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, reverseBridge, nil, nil, "", tc.opts)
 			if err != nil {
-				t.Fatalf("[%s] wrap failed: %v", m.name, err)
+				t.Fatalf("[%s] wrap failed: %v", tc.name, err)
 			}
+			mounts := parseBwrapMounts(cmd)
 
-			sk := filepath.Join(dataDir, "session.key")
-			ck := filepath.Join(dataDir, "ca-key.pem")
-			cc := filepath.Join(dataDir, "ca-cert.pem")
-			db := filepath.Join(dataDir, "greyproxy.db")
+			assertGreyproxyMaskWins(t, mounts, dataDir)
 
-			tmpfsMask := "--tmpfs " + dataDir
-			maskAt := strings.LastIndex(cmd, tmpfsMask)
-			if maskAt < 0 {
-				t.Fatalf("[%s] greyproxy data dir not masked with tmpfs; the mask is not applied in this mode", m.name)
-			}
-
-			// Key files masked with /dev/null, never re-exposed as real files.
-			for _, p := range []string{sk, ck} {
-				if !strings.Contains(cmd, "--ro-bind /dev/null "+p) {
-					t.Errorf("[%s] %q not masked with /dev/null", m.name, p)
+			if tc.hostile {
+				// Sanity: the regression scenario is actually present — a real
+				// --bind of the data dir exists before the mask. Without this,
+				// the test would pass vacuously if the bind were ever dropped.
+				maskIdx := lastDestIndex(mounts, dataDir)
+				found := false
+				for i, m := range mounts {
+					if i < maskIdx && m.dest == dataDir && (m.flag == "--bind" || m.flag == "--ro-bind") && m.src == dataDir {
+						found = true
+						break
+					}
 				}
-			}
-			for _, p := range []string{sk, ck, db} {
-				if strings.Contains(cmd, "--ro-bind "+p+" "+p) {
-					t.Errorf("[%s] secret %q re-exposed as the real file", m.name, p)
-				}
-			}
-
-			// ca-cert.pem stays readable, and its re-bind wins over the mask.
-			ccReBind := "--ro-bind " + cc + " " + cc
-			ccAt := strings.LastIndex(cmd, ccReBind)
-			if ccAt < 0 {
-				t.Errorf("[%s] ca-cert.pem not re-exposed read-only (TLS trust broken)", m.name)
-			} else if ccAt < maskAt {
-				t.Errorf("[%s] ca-cert re-bind (%d) must come after the dir mask (%d)", m.name, ccAt, maskAt)
-			}
-
-			// Nothing may re-expose the secrets AFTER the mask: assert every
-			// bind of an ancestor directory of the greyproxy dir is emitted
-			// BEFORE the mask (so "last mount wins" keeps the mask in effect).
-			ancestors := []string{
-				"--bind " + home + " " + home,                                                      // watch: writable home
-				"--ro-bind " + home + " " + home,                                                   // legacy home ro-bind
-				"--ro-bind " + filepath.Join(home, ".local") + " " + filepath.Join(home, ".local"), // deny-default home cache
-			}
-			for _, anc := range ancestors {
-				if i := strings.LastIndex(cmd, anc); i >= 0 && i > maskAt {
-					t.Errorf("[%s] ancestor bind %q at %d re-exposes greyproxy secrets AFTER the mask at %d", m.name, anc, i, maskAt)
+				if !found {
+					t.Fatalf("[%s] expected a hostile --bind %s %s before the mask; mounts=%+v", tc.name, dataDir, dataDir, mounts)
 				}
 			}
 		})
 	}
 }
 
-// indexOfPair returns the index of a two-token mount arg (flag, dest), or -1.
-func indexOfPair(args []string, flag, dest string) int {
-	for i := 0; i+1 < len(args); i++ {
-		if args[i] == flag && args[i+1] == dest {
-			return i
-		}
+// TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome guards the XDG_DATA_HOME
+// relocation path: greyproxy's dir and per-file secrets must still be masked
+// when the store lives at $XDG_DATA_HOME/greyproxy. This would fail if
+// SensitiveGreyproxyFiles() stopped honoring XDG (the per-file /dev/null masks
+// would silently no-op).
+func TestWrapCommandLinux_GreyproxyMaskWithXDGDataHome(t *testing.T) {
+	home := t.TempDir()
+	xdg := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	dataDir := seedGreyproxyDirIn(t, xdg)
+	cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, nil, nil, nil, "", LinuxSandboxOptions{UseLandlock: true, UseSeccomp: true})
+	if err != nil {
+		t.Fatalf("wrap failed: %v", err)
 	}
-	return -1
+
+	assertGreyproxyMaskWins(t, parseBwrapMounts(cmd), dataDir)
 }
 
-// indexOfTriple returns the index of a three-token mount arg (flag, src, dest),
-// or -1.
-func indexOfTriple(args []string, flag, src, dest string) int {
-	for i := 0; i+2 < len(args); i++ {
-		if args[i] == flag && args[i+1] == src && args[i+2] == dest {
-			return i
+// TestSensitiveGreyproxyPathsHonorXDG asserts the path helpers include the
+// XDG_DATA_HOME location for both dirs and per-file secrets, so dir and file
+// masks cannot diverge.
+func TestSensitiveGreyproxyPathsHonorXDG(t *testing.T) {
+	home := t.TempDir()
+	xdg := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	wantDir := filepath.Join(xdg, "greyproxy")
+	if !contains(SensitiveGreyproxyDirs(), wantDir) {
+		t.Errorf("SensitiveGreyproxyDirs missing XDG dir %q: %v", wantDir, SensitiveGreyproxyDirs())
+	}
+	for _, f := range []string{"session.key", "ca-key.pem"} {
+		want := filepath.Join(wantDir, f)
+		if !contains(SensitiveGreyproxyFiles(), want) {
+			t.Errorf("SensitiveGreyproxyFiles missing XDG secret %q: %v", want, SensitiveGreyproxyFiles())
 		}
 	}
-	return -1
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime complements the
+// command-string assertions with REAL bubblewrap enforcement: it executes the
+// generated sandbox and, from inside it, reads each greyproxy path. The seeded
+// files each contain "x", so a masked path reads empty and a re-exposed one
+// reads "x". It asserts session.key / ca-key.pem / greyproxy.db are empty
+// (masked) while the public ca-cert.pem is readable (TLS trust preserved).
+//
+// Per repo convention for runtime sandbox tests, it skips when bwrap is absent
+// or cannot create user namespaces (e.g. unprivileged CI).
+func TestWrapCommandLinux_GreyproxySecretsUnreadableAtRuntime(t *testing.T) {
+	if os.Getenv("GREYWALL_SANDBOX") == "1" {
+		t.Skip("skipping: already running inside a sandbox")
+	}
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("skipping: bwrap not found")
+	}
+
+	_, dataDir := seedGreyproxyDir(t)
+	cfg := &config.Config{Filesystem: config.FilesystemConfig{}}
+
+	sk := filepath.Join(dataDir, "session.key")
+	ck := filepath.Join(dataDir, "ca-key.pem")
+	db := filepath.Join(dataDir, "greyproxy.db")
+	cc := filepath.Join(dataDir, "ca-cert.pem")
+
+	// Read each path with a pure-bash redirection ($(<file)) so no external
+	// binary is required inside the sandbox. Unreadable/absent -> empty.
+	probe := "printf 'sk=[%s]\\n' \"$(<" + sk + ")\"; " +
+		"printf 'ck=[%s]\\n' \"$(<" + ck + ")\"; " +
+		"printf 'db=[%s]\\n' \"$(<" + db + ")\"; " +
+		"printf 'cc=[%s]\\n' \"$(<" + cc + ")\""
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, probe, nil, nil, nil, nil, nil, "", LinuxSandboxOptions{})
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	out, runErr := exec.Command("bash", "-c", cmd).CombinedOutput()
+	got := string(out)
+
+	// If bubblewrap can't stand up a namespace here, skip rather than fail.
+	if !strings.Contains(got, "sk=[") {
+		if strings.Contains(got, "Creating new namespace failed") ||
+			strings.Contains(got, "setting up uid map") ||
+			strings.Contains(got, "bwrap:") {
+			t.Skipf("skipping: bwrap cannot create a sandbox here: %v\n%s", runErr, got)
+		}
+		t.Fatalf("sandbox run produced no probe output: %v\n%s", runErr, got)
+	}
+
+	for _, masked := range []string{"sk=[]", "ck=[]", "db=[]"} {
+		if !strings.Contains(got, masked) {
+			t.Errorf("expected %q (greyproxy secret masked at runtime); output:\n%s", masked, got)
+		}
+	}
+	if !strings.Contains(got, "cc=[x]") {
+		t.Errorf("expected cc=[x] (public ca-cert readable at runtime); output:\n%s", got)
+	}
 }

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -822,6 +822,16 @@ func getMandatoryDenyPaths(cwd string) []string {
 //
 // This mirrors the intent of the macOS Seatbelt backend, which already emits an
 // explicit (deny file-read-data ...) for these paths (see macos.go).
+//
+// KNOWN LIMITATION (symlinks): the masks below act on the logical paths as
+// resolved from HOME/XDG_DATA_HOME. If an operator relocates the greyproxy data
+// dir (or an individual secret) via a symlink to a target that is separately
+// exposed by a broader bind, the tmpfs/`/dev/null` mask lands on the link path
+// and the real target may remain readable — canMountOver() also skips symlinked
+// files. This is not reachable in the standard deployment (greyproxy creates
+// real files under its data dir), so it is left as an upstream hardening item;
+// a full fix would filepath.EvalSymlinks the paths and mask both the logical and
+// resolved locations.
 func greyproxyDenyReadArgs() []string {
 	var args []string
 
@@ -1373,25 +1383,6 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 
 	} // end if !opts.Learning && !opts.Watch
 
-	// Mask greyproxy's private state (session key, CA private key, encrypted
-	// credential store and proxied logs) with deny-READ mounts.
-	//
-	// This is applied in the enforcing path AND in --watch mode, gated only on
-	// "not learning". Watch mode uses a permissive layout (root read-only, home
-	// writable) and SKIPS the deny/mask block above, but credential substitution
-	// can still be active in watch mode (it is disabled only in learning mode) —
-	// so without this the offline-decrypt attack (readable session.key +
-	// greyproxy.db) would persist under --watch. The mask itself is a no-op when
-	// greyproxy is not set up (the paths simply don't exist).
-	//
-	// Emitted last so that in bubblewrap's "last mount wins" model it is not
-	// clobbered by an earlier bind of the real files (home caches, the permissive
-	// home bind, the mandatory-deny loop, deny-write). Only the public
-	// ca-cert.pem is re-exposed read-only, for TLS trust.
-	if !opts.Learning {
-		bwrapArgs = append(bwrapArgs, greyproxyDenyReadArgs()...)
-	}
-
 	// Bind the proxy bridge Unix socket into the sandbox (needs to be writable)
 	var dnsRelayResolvConf string // temp file path for custom resolv.conf
 	var caCertPath string         // greyproxy CA cert path (if available)
@@ -1513,6 +1504,30 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 	// because the binary path doesn't exist inside the sandbox.
 	if useLandlockWrapper && greywallExePath != "" {
 		bwrapArgs = append(bwrapArgs, "--ro-bind", greywallExePath, greywallExePath)
+	}
+
+	// Mask greyproxy's private state (session key, CA private key, encrypted
+	// credential store and proxied logs) with deny-READ mounts.
+	//
+	// This is applied in the enforcing path AND in --watch mode, gated only on
+	// "not learning". Watch mode uses a permissive layout (root read-only, home
+	// writable) and SKIPS the deny/mask block above, but credential substitution
+	// can still be active in watch mode (it is disabled only in learning mode) —
+	// so without this the offline-decrypt attack (readable session.key +
+	// greyproxy.db) would persist under --watch. The mask itself is a no-op when
+	// greyproxy is not set up (the paths simply don't exist).
+	//
+	// This MUST be the final block of filesystem-mount arguments, emitted after
+	// every other bind (home caches, the permissive home bind, the mandatory-deny
+	// loop, deny-write, the proxy/DNS/reverse/forward bridge socket-dir binds, and
+	// the greywall exe bind). In bubblewrap's "last mount wins" model this is what
+	// guarantees the mask cannot be clobbered by an earlier — or a hostile,
+	// e.g. a bridge socket path placed inside the greyproxy data dir — bind of the
+	// real files. Do NOT append further filesystem binds after this block; only
+	// the "--" command separator and the inner script may follow. Only the public
+	// ca-cert.pem is re-exposed read-only, for TLS trust.
+	if !opts.Learning {
+		bwrapArgs = append(bwrapArgs, greyproxyDenyReadArgs()...)
 	}
 
 	bwrapArgs = append(bwrapArgs, "--", shellPath, "-c")

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -805,17 +805,13 @@ func getMandatoryDenyPaths(cwd string) []string {
 }
 
 // greyproxyDenyReadArgs returns bwrap args that make greyproxy's private state
-// unreadable while keeping the public ca-cert.pem readable for TLS trust.
+// unreadable while re-exposing the public ca-cert.pem for TLS trust. Secrets
+// need deny-READ (mask with /dev/null or tmpfs), not deny-WRITE (--ro-bind
+// realfile realfile leaves them readable), and MUST be appended last so
+// bubblewrap's "last mount wins" keeps the mask.
 //
-// Secrets need deny-READ (mask with /dev/null or tmpfs), not the deny-WRITE
-// idiom (--ro-bind realfile realfile) which leaves them readable. These args
-// MUST be appended after every other bind so bubblewrap's "last mount wins"
-// keeps the mask (see the call site).
-//
-// Symlink limitation: masks act on logical paths, so a data dir/secret
-// symlinked to a separately-exposed target could stay readable. Not reachable
-// in the standard deployment (greyproxy writes real files); left as upstream
-// hardening (EvalSymlinks the paths).
+// Known limitation: a symlinked data dir/secret pointing at a separately-exposed
+// target could stay readable (not reachable in the standard deployment).
 func greyproxyDenyReadArgs() []string {
 	var args []string
 
@@ -1480,12 +1476,10 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		bwrapArgs = append(bwrapArgs, "--ro-bind", greywallExePath, greywallExePath)
 	}
 
-	// Mask greyproxy's private state. Gated on "not learning" (substitution is
-	// off only in learning mode) so it also covers --watch, which skips the
-	// deny block above. MUST stay the last filesystem-mount block: bubblewrap's
-	// "last mount wins" is what stops any earlier bind — including a hostile
-	// bridge socket path inside the data dir — from re-exposing the secrets. Do
-	// not append further binds after this; only "--" and the inner script follow.
+	// Mask greyproxy's private state. MUST stay the last filesystem-mount block —
+	// "last mount wins" is what stops an earlier bind (or a hostile bridge socket
+	// inside the data dir) from re-exposing the secrets, so don't append binds
+	// after this. Gated on "not learning" so it also covers --watch.
 	if !opts.Learning {
 		bwrapArgs = append(bwrapArgs, greyproxyDenyReadArgs()...)
 	}

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -797,67 +797,41 @@ func getMandatoryDenyPaths(cwd string) []string {
 		}
 	}
 
-	// NOTE: greyproxy secrets (session key, CA private key) are deliberately NOT
-	// added here. This function feeds the deny-WRITE idiom (--ro-bind realfile
-	// realfile), which keeps a path read-only but still READABLE. That is correct
-	// for dangerous files like .bashrc, but fatal for secrets: it would re-expose
-	// the real key bytes for reading (and, being emitted after the denyRead mask,
-	// clobber it). Secrets require deny-READ treatment and are handled separately
-	// by greyproxyDenyReadArgs().
+	// greyproxy secrets are NOT added here: this set feeds the deny-WRITE idiom
+	// (--ro-bind realfile realfile), which leaves the file readable — fatal for
+	// secrets. They get deny-READ treatment in greyproxyDenyReadArgs() instead.
 
 	return paths
 }
 
-// greyproxyDenyReadArgs returns bwrap arguments that make greyproxy's private
-// state unreadable inside the sandbox while preserving the public CA
-// certificate needed for TLS trust.
+// greyproxyDenyReadArgs returns bwrap args that make greyproxy's private state
+// unreadable while keeping the public ca-cert.pem readable for TLS trust.
 //
-// These paths require deny-READ treatment (an empty /dev/null bind for files, an
-// empty tmpfs for directories) rather than the deny-WRITE idiom (--ro-bind
-// realfile realfile) used for dangerous files such as .bashrc. Binding the real
-// file read-only would leave the secret READABLE. The returned args must be
-// appended AFTER every other filesystem bind (home caches, mandatory deny,
-// deny-write) so that in bubblewrap's "last mount wins" model the mask is not
-// clobbered by an earlier bind of the real bytes.
+// Secrets need deny-READ (mask with /dev/null or tmpfs), not the deny-WRITE
+// idiom (--ro-bind realfile realfile) which leaves them readable. These args
+// MUST be appended after every other bind so bubblewrap's "last mount wins"
+// keeps the mask (see the call site).
 //
-// This mirrors the intent of the macOS Seatbelt backend, which already emits an
-// explicit (deny file-read-data ...) for these paths (see macos.go).
-//
-// KNOWN LIMITATION (symlinks): the masks below act on the logical paths as
-// resolved from HOME/XDG_DATA_HOME. If an operator relocates the greyproxy data
-// dir (or an individual secret) via a symlink to a target that is separately
-// exposed by a broader bind, the tmpfs/`/dev/null` mask lands on the link path
-// and the real target may remain readable — canMountOver() also skips symlinked
-// files. This is not reachable in the standard deployment (greyproxy creates
-// real files under its data dir), so it is left as an upstream hardening item;
-// a full fix would filepath.EvalSymlinks the paths and mask both the logical and
-// resolved locations.
+// Symlink limitation: masks act on logical paths, so a data dir/secret
+// symlinked to a separately-exposed target could stay readable. Not reachable
+// in the standard deployment (greyproxy writes real files); left as upstream
+// hardening (EvalSymlinks the paths).
 func greyproxyDenyReadArgs() []string {
 	var args []string
 
-	// Replace each greyproxy data directory with an empty tmpfs. This hides the
-	// encrypted credential store (greyproxy.db plus its -wal/-shm side files),
-	// the session key, the CA private key, and any proxied request/response logs
-	// in one shot, instead of wholesale-binding the directory read-only (which
-	// the generic home-cache bind of ~/.local would otherwise do).
+	// tmpfs the whole data dir: hides the store, keys, and proxied logs at once.
 	for _, dir := range SensitiveGreyproxyDirs() {
 		if isDirectory(dir) {
 			args = append(args, "--tmpfs", dir)
 		}
 	}
-
-	// Defense in depth: explicitly mask each individual sensitive file with an
-	// empty, unreadable file. This also protects installations where the file
-	// lives outside a directory covered above.
+	// Defense in depth: mask each secret file individually.
 	for _, p := range SensitiveGreyproxyFiles() {
 		if fileExists(p) && canMountOver(p) {
 			args = append(args, "--ro-bind", "/dev/null", p)
 		}
 	}
-
-	// Re-expose ONLY the public CA certificate (read-only) so sandboxed clients
-	// can still trust the greyproxy MITM CA. Emitted last so it wins over the
-	// tmpfs mask for this single, non-sensitive file.
+	// Re-expose only the public CA cert, last so it wins over the tmpfs.
 	if certPath := greyproxyCACertPath(); certPath != "" {
 		args = append(args, "--ro-bind", certPath, certPath)
 	}
@@ -1506,26 +1480,12 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		bwrapArgs = append(bwrapArgs, "--ro-bind", greywallExePath, greywallExePath)
 	}
 
-	// Mask greyproxy's private state (session key, CA private key, encrypted
-	// credential store and proxied logs) with deny-READ mounts.
-	//
-	// This is applied in the enforcing path AND in --watch mode, gated only on
-	// "not learning". Watch mode uses a permissive layout (root read-only, home
-	// writable) and SKIPS the deny/mask block above, but credential substitution
-	// can still be active in watch mode (it is disabled only in learning mode) —
-	// so without this the offline-decrypt attack (readable session.key +
-	// greyproxy.db) would persist under --watch. The mask itself is a no-op when
-	// greyproxy is not set up (the paths simply don't exist).
-	//
-	// This MUST be the final block of filesystem-mount arguments, emitted after
-	// every other bind (home caches, the permissive home bind, the mandatory-deny
-	// loop, deny-write, the proxy/DNS/reverse/forward bridge socket-dir binds, and
-	// the greywall exe bind). In bubblewrap's "last mount wins" model this is what
-	// guarantees the mask cannot be clobbered by an earlier — or a hostile,
-	// e.g. a bridge socket path placed inside the greyproxy data dir — bind of the
-	// real files. Do NOT append further filesystem binds after this block; only
-	// the "--" command separator and the inner script may follow. Only the public
-	// ca-cert.pem is re-exposed read-only, for TLS trust.
+	// Mask greyproxy's private state. Gated on "not learning" (substitution is
+	// off only in learning mode) so it also covers --watch, which skips the
+	// deny block above. MUST stay the last filesystem-mount block: bubblewrap's
+	// "last mount wins" is what stops any earlier bind — including a hostile
+	// bridge socket path inside the data dir — from re-exposing the secrets. Do
+	// not append further binds after this; only "--" and the inner script follow.
 	if !opts.Learning {
 		bwrapArgs = append(bwrapArgs, greyproxyDenyReadArgs()...)
 	}

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -797,10 +797,62 @@ func getMandatoryDenyPaths(cwd string) []string {
 		}
 	}
 
-	// Sensitive system files (greyproxy encryption key, CA private key)
-	paths = append(paths, GetSensitiveSystemPaths()...)
+	// NOTE: greyproxy secrets (session key, CA private key) are deliberately NOT
+	// added here. This function feeds the deny-WRITE idiom (--ro-bind realfile
+	// realfile), which keeps a path read-only but still READABLE. That is correct
+	// for dangerous files like .bashrc, but fatal for secrets: it would re-expose
+	// the real key bytes for reading (and, being emitted after the denyRead mask,
+	// clobber it). Secrets require deny-READ treatment and are handled separately
+	// by greyproxyDenyReadArgs().
 
 	return paths
+}
+
+// greyproxyDenyReadArgs returns bwrap arguments that make greyproxy's private
+// state unreadable inside the sandbox while preserving the public CA
+// certificate needed for TLS trust.
+//
+// These paths require deny-READ treatment (an empty /dev/null bind for files, an
+// empty tmpfs for directories) rather than the deny-WRITE idiom (--ro-bind
+// realfile realfile) used for dangerous files such as .bashrc. Binding the real
+// file read-only would leave the secret READABLE. The returned args must be
+// appended AFTER every other filesystem bind (home caches, mandatory deny,
+// deny-write) so that in bubblewrap's "last mount wins" model the mask is not
+// clobbered by an earlier bind of the real bytes.
+//
+// This mirrors the intent of the macOS Seatbelt backend, which already emits an
+// explicit (deny file-read-data ...) for these paths (see macos.go).
+func greyproxyDenyReadArgs() []string {
+	var args []string
+
+	// Replace each greyproxy data directory with an empty tmpfs. This hides the
+	// encrypted credential store (greyproxy.db plus its -wal/-shm side files),
+	// the session key, the CA private key, and any proxied request/response logs
+	// in one shot, instead of wholesale-binding the directory read-only (which
+	// the generic home-cache bind of ~/.local would otherwise do).
+	for _, dir := range SensitiveGreyproxyDirs() {
+		if isDirectory(dir) {
+			args = append(args, "--tmpfs", dir)
+		}
+	}
+
+	// Defense in depth: explicitly mask each individual sensitive file with an
+	// empty, unreadable file. This also protects installations where the file
+	// lives outside a directory covered above.
+	for _, p := range SensitiveGreyproxyFiles() {
+		if fileExists(p) && canMountOver(p) {
+			args = append(args, "--ro-bind", "/dev/null", p)
+		}
+	}
+
+	// Re-expose ONLY the public CA certificate (read-only) so sandboxed clients
+	// can still trust the greyproxy MITM CA. Emitted last so it wins over the
+	// tmpfs mask for this single, non-sensitive file.
+	if certPath := greyproxyCACertPath(); certPath != "" {
+		args = append(args, "--ro-bind", certPath, certPath)
+	}
+
+	return args
 }
 
 // buildDenyByDefaultMounts builds bwrap arguments for deny-by-default filesystem isolation.
@@ -1320,6 +1372,25 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, proxyBridge
 		}
 
 	} // end if !opts.Learning && !opts.Watch
+
+	// Mask greyproxy's private state (session key, CA private key, encrypted
+	// credential store and proxied logs) with deny-READ mounts.
+	//
+	// This is applied in the enforcing path AND in --watch mode, gated only on
+	// "not learning". Watch mode uses a permissive layout (root read-only, home
+	// writable) and SKIPS the deny/mask block above, but credential substitution
+	// can still be active in watch mode (it is disabled only in learning mode) —
+	// so without this the offline-decrypt attack (readable session.key +
+	// greyproxy.db) would persist under --watch. The mask itself is a no-op when
+	// greyproxy is not set up (the paths simply don't exist).
+	//
+	// Emitted last so that in bubblewrap's "last mount wins" model it is not
+	// clobbered by an earlier bind of the real files (home caches, the permissive
+	// home bind, the mandatory-deny loop, deny-write). Only the public
+	// ca-cert.pem is re-exposed read-only, for TLS trust.
+	if !opts.Learning {
+		bwrapArgs = append(bwrapArgs, greyproxyDenyReadArgs()...)
+	}
 
 	// Bind the proxy bridge Unix socket into the sandbox (needs to be writable)
 	var dnsRelayResolvConf string // temp file path for custom resolv.conf

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -276,7 +276,7 @@ func generateReadRules(defaultDenyRead bool, cwd string, allowPaths, denyPaths [
 	}
 
 	// Deny sensitive system files (greyproxy encryption key, CA private key)
-	for _, p := range GetSensitiveSystemPaths() {
+	for _, p := range SensitiveGreyproxyFiles() {
 		rules = append(
 			rules,
 			"(deny file-read-data",


### PR DESCRIPTION
## Summary

On Linux, the files greyproxy uses to protect credentials were readable from
inside the sandbox. A process running in the sandbox could read the session key
and the encrypted credential store and reconstruct the real upstream credential
entirely offline — without ever talking to greyproxy. That undermines the point
of running untrusted code in the sandbox in the first place.

The sandbox *did* try to hide those files, but it mounted them read-only instead
of unreadable — and that mount was applied after the step meant to hide them, so
it silently undid the protection. macOS was unaffected; it already blocks reads
on these paths.

## Fix

Hide greyproxy's private data properly: replace its data directory with an empty
one inside the sandbox and block each secret file, leaving only the public CA
certificate the sandbox legitimately needs for TLS. This masking is now the last
filesystem step, so nothing applied afterward can re-expose the files, and it
also covers `--watch` mode. Credential injection and the network egress rules are
unchanged.

## Testing

Added tests that confirm the secrets are unreadable — including one that stands
up a real sandbox and tries to read each file from inside it — and that
specifically guard the ordering, so a future change that re-exposed the files
would fail. `make fmt` and `make lint` are clean.
