### PR TITLE
fix(linux): detect AppArmor network capability restrictions

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,27 +21,18 @@ This is a macOS kernel limitation - nested Seatbelt sandboxes are not allowed. T
 
 ## "bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted" (Linux)
 
-This error occurs when greywall tries to create a network namespace but the environment lacks the `CAP_NET_ADMIN` capability. This is common in:
+This error occurs when the environment prevents Greywall's Bubblewrap child from administering its network namespace. This is common in:
 
 - **Docker containers** (unless run with `--privileged` or `--cap-add=NET_ADMIN`)
 - **GitHub Actions** and other CI runners
-- **Ubuntu 24.04+** with restrictive AppArmor policies
+- **Ubuntu 24.04+** where AppArmor allows Bubblewrap to create namespaces but removes child capabilities
 - **Kubernetes pods** without elevated security contexts
 
 **What happens now:**
 
-Greywall automatically detects this limitation and falls back to running **without network namespace isolation**. The sandbox still provides:
+Greywall probes both namespace creation and child-side TUN access. If TUN setup is unavailable but the network namespace works, Greywall keeps the namespace and uses `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` instead. Programs that honor those variables can reach the configured proxy; programs that ignore them remain blocked by the namespace.
 
-- Filesystem restrictions (read-only root, allowWrite paths)
-- PID namespace isolation
-- Seccomp syscall filtering
-- Landlock (if available)
-
-**What's reduced:**
-
-- Network isolation via namespace is skipped
-- Proxy-based routing still works (via `HTTP_PROXY`/`HTTPS_PROXY` env vars)
-- But programs that bypass proxy env vars won't be network-isolated
+If the network namespace itself is unavailable, Greywall retains its filesystem, PID, seccomp, and Landlock restrictions, but direct network access is not contained. `greywall check` reports this weaker state explicitly.
 
 **To check if your environment supports network namespaces:**
 
@@ -51,23 +42,12 @@ greywall --linux-features
 
 Look for "Network namespace (--unshare-net): true/false"
 
-**Solutions if you need full network isolation:**
+**Solutions if you need transparent proxying:**
 
-1. **Run with elevated privileges:**
-
-   ```bash
-   sudo greywall <command>
-   ```
-
-2. **In Docker, add capability:**
-
-   ```bash
-   docker run --cap-add=NET_ADMIN ...
-   ```
-
-3. **In GitHub Actions**, this typically isn't possible without self-hosted runners with elevated permissions.
-
-4. **On Ubuntu 24.04+**, you may need to modify AppArmor profiles (see [Ubuntu bug 2069526](https://bugs.launchpad.net/bugs/2069526)).
+1. Prefer an application that honors standard proxy environment variables; the network namespace still prevents bypass.
+2. In containers, grant `NET_ADMIN` only to the container running Greywall when that is acceptable for your threat model.
+3. In CI, use a self-hosted runner whose sandbox policy supports child-side TUN administration.
+4. On Ubuntu 24.04+, use a narrowly scoped AppArmor policy reviewed for your deployment. Do not disable AppArmor's unprivileged-user-namespace restriction globally.
 
 ## "bwrap: setting up uid map: Permission denied" (Linux)
 

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -1727,6 +1727,7 @@ func PrintLinuxFeatures() {
 	fmt.Printf("  Bubblewrap (bwrap): %v\n", features.HasBwrap)
 	fmt.Printf("  Socat: %v\n", features.HasSocat)
 	fmt.Printf("  Network namespace (--unshare-net): %v\n", features.CanUnshareNet)
+	fmt.Printf("  Network administration (TUN/CAP_NET_ADMIN): %v\n", features.CanAdminNet)
 	fmt.Printf("  Seccomp: %v (log level: %d)\n", features.HasSeccomp, features.SeccompLogLevel)
 	fmt.Printf("  Landlock: %v (ABI v%d)\n", features.HasLandlock, features.LandlockABI)
 	fmt.Printf("  eBPF: %v (CAP_BPF: %v, root: %v)\n", features.HasEBPF, features.HasCapBPF, features.HasCapRoot)
@@ -1759,7 +1760,10 @@ func PrintLinuxFeatures() {
 	if features.CanUseTransparentProxy() {
 		fmt.Printf("  ✓ Transparent proxy available (tun2socks + TUN device)\n")
 	} else {
-		fmt.Printf("  ○ Transparent proxy not available (needs ip, /dev/net/tun, network namespace)\n")
+		fmt.Printf("  ○ Transparent proxy not available (needs ip, /dev/net/tun, network namespace, and child CAP_NET_ADMIN)\n")
+		if features.CanUnshareNet {
+			fmt.Printf("    Proxy-aware applications will use HTTP_PROXY/HTTPS_PROXY/ALL_PROXY instead.\n")
+		}
 	}
 
 	if features.CanUseLandlock() {

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -31,9 +31,10 @@ type LinuxFeatures struct {
 	HasCapBPF  bool
 	HasCapRoot bool
 
-	// Network namespace capability
-	// This can be false in containerized environments (Docker, CI) without CAP_NET_ADMIN
-	CanUnshareNet bool
+	// Network namespace capabilities
+	// These can be restricted independently by AppArmor and container runtimes.
+	CanUnshareNet bool // bwrap can create a network namespace
+	CanAdminNet   bool // a bwrap child retains CAP_NET_ADMIN in that namespace
 
 	// Transparent proxy support
 	HasIpCommand bool // ip (iproute2) available
@@ -77,14 +78,16 @@ func (f *LinuxFeatures) detect() {
 	// Check eBPF capabilities
 	f.detectEBPF()
 
-	// Check if we can create network namespaces
-	f.detectNetworkNamespace()
-
-	// Check transparent proxy support
+	// Check transparent proxy prerequisites before probing whether a child can
+	// administer its network namespace. AppArmor can allow namespace creation
+	// while stripping CAP_NET_ADMIN from the executable launched by bwrap.
 	f.HasIpCommand = commandExists("ip")
 	_, err := os.Stat("/dev/net/tun")
 	f.HasDevNetTun = err == nil
 	f.HasTun2Socks = true // embedded binary, always available
+
+	f.detectNetworkNamespace()
+	f.detectNetworkAdministration()
 }
 
 func (f *LinuxFeatures) parseKernelVersion() {
@@ -219,8 +222,33 @@ func (f *LinuxFeatures) detectNetworkNamespace() {
 	}
 
 	cmd := exec.Command("bwrap", "--unshare-net", "--ro-bind", "/", "/", "--", truePath) //nolint:gosec
-	err = cmd.Run()
-	f.CanUnshareNet = err == nil
+	f.CanUnshareNet = cmd.Run() == nil
+}
+
+// detectNetworkAdministration probes the exact child-side capability Greywall
+// needs to create its transparent proxy. Ubuntu's bwrap AppArmor profile can
+// allow --unshare-net while denying CAP_NET_ADMIN after bwrap execs its child.
+func (f *LinuxFeatures) detectNetworkAdministration() {
+	if !f.CanUnshareNet || !f.HasIpCommand || !f.HasDevNetTun {
+		return
+	}
+
+	ipPath, err := exec.LookPath("ip")
+	if err != nil {
+		return
+	}
+
+	// Creating a disposable TUN interface tests both CAP_NET_ADMIN and
+	// TUNSETIFF access. The namespace is destroyed when the probe exits.
+	cmd := exec.Command( //nolint:gosec
+		"bwrap",
+		"--unshare-net",
+		"--ro-bind", "/", "/",
+		"--dev-bind", "/dev/net/tun", "/dev/net/tun",
+		"--cap-add", "CAP_NET_ADMIN",
+		"--", ipPath, "tuntap", "add", "dev", "greywall-probe0", "mode", "tun",
+	)
+	f.CanAdminNet = cmd.Run() == nil
 }
 
 // Summary returns a human-readable summary of available features.
@@ -274,7 +302,7 @@ func (f *LinuxFeatures) CanUseLandlock() bool {
 
 // CanUseTransparentProxy returns true if transparent proxying via tun2socks is possible.
 func (f *LinuxFeatures) CanUseTransparentProxy() bool {
-	return f.HasIpCommand && f.HasDevNetTun && f.CanUnshareNet
+	return f.HasIpCommand && f.HasDevNetTun && f.CanUnshareNet && f.CanAdminNet
 }
 
 // MinimumViable returns true if the minimum required features are available.
@@ -356,21 +384,14 @@ func PrintDependencyStatus() []string {
 		}
 		if !features.CanUnshareNet {
 			missing = append(missing, "network namespace")
+		} else if !features.CanAdminNet {
+			missing = append(missing, "CAP_NET_ADMIN/TUN access")
 		}
-		if len(missing) > 0 {
-			fmt.Println(CheckFail(fmt.Sprintf("network isolation (missing: %s)", strings.Join(missing, ", "))))
+		fmt.Println(CheckFail(fmt.Sprintf("transparent network proxy (unavailable: %s)", strings.Join(missing, ", "))))
+		if features.CanUnshareNet {
+			fmt.Println(CheckOK("network namespace isolation (proxy-aware applications use environment variables)"))
 		} else {
-			fmt.Println(CheckFail("network isolation"))
-		}
-
-		if !features.CanUnshareNet && features.HasBwrap {
-			if val := readSysctl("kernel/apparmor_restrict_unprivileged_userns"); val == "1" {
-				steps = append(
-					steps,
-					"sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0",
-					"echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/99-greywall-userns.conf",
-				)
-			}
+			fmt.Println(CheckFail("network namespace isolation — direct network access is not contained"))
 		}
 	}
 
@@ -441,14 +462,6 @@ func suggestInstallSecretTool() string {
 	default:
 		return "install libsecret-tools (provides secret-tool) using your package manager"
 	}
-}
-
-func readSysctl(name string) string {
-	data, err := os.ReadFile("/proc/sys/" + name) //nolint:gosec // reading sysctl values - trusted kernel path
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
 }
 
 func commandExists(name string) bool {

--- a/internal/sandbox/linux_features_stub.go
+++ b/internal/sandbox/linux_features_stub.go
@@ -21,6 +21,7 @@ type LinuxFeatures struct {
 	HasCapBPF       bool
 	HasCapRoot      bool
 	CanUnshareNet   bool
+	CanAdminNet     bool
 	HasIpCommand    bool
 	HasDevNetTun    bool
 	HasTun2Socks    bool

--- a/internal/sandbox/linux_features_test.go
+++ b/internal/sandbox/linux_features_test.go
@@ -1,0 +1,111 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCanUseTransparentProxyRequiresChildNetworkAdministration(t *testing.T) {
+	features := LinuxFeatures{
+		HasIpCommand:  true,
+		HasDevNetTun:  true,
+		CanUnshareNet: true,
+	}
+
+	if features.CanUseTransparentProxy() {
+		t.Fatal("transparent proxy must be disabled when the bwrap child lacks CAP_NET_ADMIN")
+	}
+
+	features.CanAdminNet = true
+	if !features.CanUseTransparentProxy() {
+		t.Fatal("transparent proxy should be enabled when all prerequisites are available")
+	}
+}
+
+func TestDetectNetworkAdministrationProbesDisposableTun(t *testing.T) {
+	binDir := t.TempDir()
+	argsFile := filepath.Join(t.TempDir(), "bwrap-args")
+	writeExecutable(t, filepath.Join(binDir, "ip"), "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "bwrap"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GREYWALL_TEST_ARGS\"\nexit 0\n")
+	t.Setenv("PATH", binDir)
+	t.Setenv("GREYWALL_TEST_ARGS", argsFile)
+
+	features := LinuxFeatures{
+		CanUnshareNet: true,
+		HasIpCommand:  true,
+		HasDevNetTun:  true,
+	}
+	features.detectNetworkAdministration()
+
+	if !features.CanAdminNet {
+		t.Fatal("expected successful child network administration probe")
+	}
+	data, err := os.ReadFile(argsFile) //nolint:gosec // path is created by this test
+	if err != nil {
+		t.Fatalf("read probe arguments: %v", err)
+	}
+	args := string(data)
+	for _, expected := range []string{"--unshare-net", "--cap-add", "CAP_NET_ADMIN", "tuntap", "greywall-probe0", "tun"} {
+		if !strings.Contains(args, expected+"\n") {
+			t.Errorf("probe arguments do not contain %q:\n%s", expected, args)
+		}
+	}
+}
+
+func TestDetectNetworkAdministrationHandlesDeniedCapability(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "ip"), "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "bwrap"), "#!/bin/sh\nexit 1\n")
+	t.Setenv("PATH", binDir)
+
+	features := LinuxFeatures{
+		CanUnshareNet: true,
+		HasIpCommand:  true,
+		HasDevNetTun:  true,
+	}
+	features.detectNetworkAdministration()
+
+	if features.CanAdminNet {
+		t.Fatal("denied child network administration must disable transparent proxying")
+	}
+}
+
+// TestDetectNetworkAdministrationSkipsWithoutPrerequisites verifies the probe
+// returns early instead of shelling out when it cannot succeed. The stubbed
+// bwrap on PATH reports success, so CanAdminNet becoming true would mean the
+// guard was bypassed and the probe ran anyway.
+func TestDetectNetworkAdministrationSkipsWithoutPrerequisites(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "ip"), "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "bwrap"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+
+	cases := map[string]LinuxFeatures{
+		"no network namespace": {HasIpCommand: true, HasDevNetTun: true},
+		"no ip command":        {CanUnshareNet: true, HasDevNetTun: true},
+		"no /dev/net/tun":      {CanUnshareNet: true, HasIpCommand: true},
+	}
+
+	for name, features := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.detectNetworkAdministration()
+			if features.CanAdminNet {
+				t.Errorf("probe executed despite %s", name)
+			}
+		})
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write test executable: %v", err)
+	}
+	if err := os.Chmod(path, 0o700); err != nil { //nolint:gosec // test helper must create executable stubs
+		t.Fatalf("make test executable runnable: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #104.

## Problem

`CanUseTransparentProxy()` checked only that `ip` and `/dev/net/tun` exist and that a network namespace can be created:

```go
return f.HasIpCommand && f.HasDevNetTun && f.CanUnshareNet
```

All three hold on Ubuntu 24.04+, where `/etc/apparmor.d/bwrap-userns-restrict` (shipped by the `apparmor` package) stacks an `unpriv_bwrap` profile onto everything bwrap spawns, carrying an unconditional `audit deny capability`. `linux.go` asks bwrap for exactly the capabilities that rule strips:

```go
bwrapArgs = append(bwrapArgs, "--cap-add", "CAP_NET_ADMIN")
bwrapArgs = append(bwrapArgs, "--cap-add", "CAP_NET_BIND_SERVICE")
```

bwrap grants them inside the user namespace; AppArmor vetoes them at the LSM layer. The result is that `check` reports `✓ network isolation`, and then at runtime TUN setup fails:

```
RTNETLINK answers: Operation not permitted
ioctl(TUNSETIFF): Operation not permitted
Cannot find device "tun0"
```

`detectNetworkNamespace()` cannot catch this — the `true` it runs as a probe needs no capabilities, so it succeeds either way.

## Change

- Add `CanAdminNet`, probed by attempting a real TUN create inside bwrap rather than inferring from prerequisites. The probe device lives in the probe's own network namespace and is torn down with it.
- Require it in `CanUseTransparentProxy()`.
- Report the two states separately. The network namespace is still applied, so this is a graceful degradation to env-var proxying, not a loss of containment — programs honouring `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` still reach the proxy, and programs ignoring them stay blocked by the namespace. `check` now says so explicitly instead of claiming full network isolation.
- Update `docs/troubleshooting.md` to describe the capability-strip case, which is distinct from the existing "no network namespace at all" case.

Before / after on an affected system:

```
-  ✓ network isolation
+  ✗ transparent network proxy (unavailable: CAP_NET_ADMIN/TUN access)
+  ✓ network namespace isolation (proxy-aware applications use environment variables)
```

## Testing

Verified on a clean Ubuntu 26.04 LTS VM (kernel 7.0.0-29-generic) with stock AppArmor, `kernel.apparmor_restrict_unprivileged_userns=1`, confirmed confined as `bwrap//&unpriv_bwrap (enforce)`.

- `make test` — pass
- `make lint` (golangci-lint v1.64.8) — 0 issues
- `gofmt` — clean
- Cross-compiled `GOOS=darwin` arm64 and amd64 to cover the `!linux` stub
- Causal check: with the profile loaded, `--linux-features` reports `Network administration (TUN/CAP_NET_ADMIN): false` and the TUN errors are gone. After `apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict`, it reports `true` and behaviour is unchanged from before this patch — so there is no regression on unaffected systems.

Four new tests cover the truth table, the probe's constructed argv, the denied-capability path, and the early-return guard when prerequisites are missing.

## Notes

- `TestLinux_TransparentProxyRoutesThroughSocks` skips without `GREYWALL_TEST_NETWORK=1` and a SOCKS5 proxy on `localhost:1080`, so the integration test nearest this path did not run.
- `GOOS=windows` fails to build (`syscall.SIGWINCH`/`SIGUSR1`/`SIGUSR2` undefined in `cmd/greywall/main.go`), but identically on unpatched `main` — pre-existing and unrelated.
- Worth noting for anyone who hits this: neither `/etc/apparmor.d/local/unpriv_bwrap` nor `sysctl kernel.apparmor_restrict_unprivileged_userns=0` lifts the restriction. The first is defeated by `deny` taking precedence over `allow`; the second does not affect a profile attached to the `/usr/bin/bwrap` path. Only unloading the profile system-wide works, which is not advisable.
